### PR TITLE
Check LD_LIBRARY_PATH on setup

### DIFF
--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -111,7 +111,16 @@ class CUDASetup:
         package_dir = Path(__file__).parent.parent
         binary_path = package_dir / binary_name
 
-        print('bin', binary_path)
+        if not binary_path.exists():
+            # If binary file does not exist, check LD_LIBRARY_PATH
+            library_paths = os.getenv("LD_LIBRARY_PATH", "").split(":")
+        for path in library_paths:
+            potential_binary_path = Path(path) / binary_name
+            if potential_binary_path.exists():
+                binary_path = potential_binary_path
+                break
+
+        print("bin", binary_path)
 
         try:
             if not binary_path.exists():

--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -115,13 +115,13 @@ class CUDASetup:
             # If binary file does not exist, check LD_LIBRARY_PATH
             library_paths = os.getenv("LD_LIBRARY_PATH", "").split(":")
             print("library_paths ", library_paths)
-        for path in library_paths:
-            potential_binary_path = Path(path) / binary_name
-            print("potential_binary_path", potential_binary_path)
-            if potential_binary_path.exists():
-                binary_path = potential_binary_path
-                print("binary_path", binary_path)
-                break
+            for path in library_paths:
+                potential_binary_path = Path(path) / binary_name
+                print("potential_binary_path", potential_binary_path)
+                if potential_binary_path.exists():
+                    binary_path = potential_binary_path
+                    print("binary_path", binary_path)
+                    break
 
         print("bin", binary_path)
 

--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -114,10 +114,13 @@ class CUDASetup:
         if not binary_path.exists():
             # If binary file does not exist, check LD_LIBRARY_PATH
             library_paths = os.getenv("LD_LIBRARY_PATH", "").split(":")
+            print("library_paths ", library_paths)
         for path in library_paths:
             potential_binary_path = Path(path) / binary_name
+            print("potential_binary_path", potential_binary_path)
             if potential_binary_path.exists():
                 binary_path = potential_binary_path
+                print("binary_path", binary_path)
                 break
 
         print("bin", binary_path)


### PR DESCRIPTION
Issue:
Instructions when compiling to source require setting the destination of binaries in env var LD_LIBRARY_PATH.
This env is not checked during library setup, so unshipped self-compiled binaries will remain undetected.
Soln:
Adds a check to LD_LIBRARY PATH.