### PR TITLE
Add sm_90a to enable use of accelerated wgmma and setmaxnreg instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ CC_cublasLt111 += -gencode arch=compute_80,code=sm_80
 CC_cublasLt111 += -gencode arch=compute_86,code=sm_86
 
 CC_ADA_HOPPER := -gencode arch=compute_89,code=sm_89
-CC_ADA_HOPPER += -gencode arch=compute_90,code=sm_90
+CC_ADA_HOPPER += -gencode arch=compute_90a,code=sm_90a
 
 
 all: $(BUILD_DIR) env


### PR DESCRIPTION
sm_90a adds support for accelerated wgmma and setmaxnreg instructions.


https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#ptx-module-directives-target