### PR TITLE
Fixed optim update error with non-contiguous grads/params

### DIFF
--- a/bitsandbytes/optim/optimizer.py
+++ b/bitsandbytes/optim/optimizer.py
@@ -474,9 +474,13 @@ class Optimizer2State(Optimizer8bit):
 
     @torch.no_grad()
     def update_step(self, group, p, gindex, pindex):
+        # avoid update error from non-contiguous memory layout
+        p.data = p.data.contiguous()
+        p.grad = p.grad.contiguous()
+        
         state = self.state[p]
         grad = p.grad
-
+        
         config = self.get_config(gindex, pindex, group)
 
         state["step"] += 1
@@ -685,6 +689,10 @@ class Optimizer1State(Optimizer8bit):
 
     @torch.no_grad()
     def update_step(self, group, p, gindex, pindex):
+        # avoid update error from non-contiguous memory layout
+        p.data = p.data.contiguous()
+        p.grad = p.grad.contiguous()
+        
         state = self.state[p]
         grad = p.grad
 

--- a/bitsandbytes/optim/optimizer.py
+++ b/bitsandbytes/optim/optimizer.py
@@ -477,10 +477,10 @@ class Optimizer2State(Optimizer8bit):
         # avoid update error from non-contiguous memory layout
         p.data = p.data.contiguous()
         p.grad = p.grad.contiguous()
-        
+
         state = self.state[p]
         grad = p.grad
-        
+
         config = self.get_config(gindex, pindex, group)
 
         state["step"] += 1
@@ -692,7 +692,7 @@ class Optimizer1State(Optimizer8bit):
         # avoid update error from non-contiguous memory layout
         p.data = p.data.contiguous()
         p.grad = p.grad.contiguous()
-        
+
         state = self.state[p]
         grad = p.grad
 


### PR DESCRIPTION
Fixes #1185 
Non-contiguous params/gradients resulting from `torch.chunk` and `all_gather` etc. are ubiquitous in distributed training frameworks such as ZeRO. This avoids update errors as the C++ kernels assume row-major inputs. 

<img width="1088" alt="image" src="https://github.com/TimDettmers/bitsandbytes/assets/87317405/58f7af35-d93e-490a-8216-fe5fb64aff44">
cc @Titus-von-Koeller 