### PR TITLE
TESTS: add `is_flaky` decorator on flaky tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,6 +2,8 @@ import functools
 from io import BytesIO
 from itertools import product
 import random
+import sys
+import time
 from typing import Any, List
 
 import torch

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -64,7 +64,6 @@ DTYPE_NAMES = {
 def describe_dtype(dtype: torch.dtype) -> str:
     return DTYPE_NAMES.get(dtype) or str(dtype).rpartition(".")[2]
 
-
 # Copied from: https://github.com/huggingface/transformers/blob/2d92db8458f7143f64f9b13cbcfee5eb8d0cab90/src/transformers/testing_utils.py#L2131
 def is_flaky(max_attempts = 5, wait_before_retry = None, description = None):
     """

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,7 @@
+import functools
 from io import BytesIO
 from itertools import product
 import random
-import functools
 from typing import Any, List
 
 import torch
@@ -64,8 +64,9 @@ DTYPE_NAMES = {
 def describe_dtype(dtype: torch.dtype) -> str:
     return DTYPE_NAMES.get(dtype) or str(dtype).rpartition(".")[2]
 
+
 # Copied from: https://github.com/huggingface/transformers/blob/2d92db8458f7143f64f9b13cbcfee5eb8d0cab90/src/transformers/testing_utils.py#L2131
-def is_flaky(max_attempts = 5, wait_before_retry = None, description = None):
+def is_flaky(max_attempts=5, wait_before_retry=None, description=None):
     """
     To decorate flaky tests. They will be retried on failures.
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 from itertools import product
 import random
+import functools
 from typing import Any, List
 
 import torch
@@ -62,3 +63,40 @@ DTYPE_NAMES = {
 
 def describe_dtype(dtype: torch.dtype) -> str:
     return DTYPE_NAMES.get(dtype) or str(dtype).rpartition(".")[2]
+
+
+# Copied from: https://github.com/huggingface/transformers/blob/2d92db8458f7143f64f9b13cbcfee5eb8d0cab90/src/transformers/testing_utils.py#L2131
+def is_flaky(max_attempts = 5, wait_before_retry = None, description = None):
+    """
+    To decorate flaky tests. They will be retried on failures.
+
+    Args:
+        max_attempts (`int`, *optional*, defaults to 5):
+            The maximum number of attempts to retry the flaky test.
+        wait_before_retry (`float`, *optional*):
+            If provided, will wait that number of seconds before retrying the test.
+        description (`str`, *optional*):
+            A string to describe the situation (what / where / why is flaky, link to GH issue/PR comments, errors,
+            etc.)
+    """
+
+    def decorator(test_func_ref):
+        @functools.wraps(test_func_ref)
+        def wrapper(*args, **kwargs):
+            retry_count = 1
+
+            while retry_count < max_attempts:
+                try:
+                    return test_func_ref(*args, **kwargs)
+
+                except Exception as err:
+                    print(f"Test failed with {err} at try {retry_count}/{max_attempts}.", file=sys.stderr)
+                    if wait_before_retry is not None:
+                        time.sleep(wait_before_retry)
+                    retry_count += 1
+
+            return test_func_ref(*args, **kwargs)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
# What does this PR do?

This PR introduces a new pytest decorator `is_flaky` that runs tests that have been decorated as being flaky. The decorator will run the test `max_attempts` times and if the test failed during all these attempts the test will be marked as failed.

Plan forward: identify which tests are flaky and decorate them

cc @Titus-von-Koeller 