### PR TITLE
Fixed tests for cpu only platforms

### DIFF
--- a/tests/test_linear8bitlt.py
+++ b/tests/test_linear8bitlt.py
@@ -182,7 +182,7 @@ def test_linear_serialization(
 
 
 @pytest.fixture
-def linear8bit():
+def linear8bit(requires_cuda):
     linear = torch.nn.Linear(32, 96)
     linear_custom = Linear8bitLt(
         linear.in_features,

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -616,7 +616,7 @@ def test_fp8linear():
     assert bgraderr < 0.00002
 
 
-def test_4bit_warnings():
+def test_4bit_warnings(requires_cuda):
     dim1 = 64
 
     with pytest.warns(UserWarning, match=r"inference or training"):


### PR DESCRIPTION
`test_4bit_warnings` is the only test that fails on cpu only platforms with CUDA-enabled torch.

The reason for this is that other tests fall into [this](https://github.com/TimDettmers/bitsandbytes/blob/dada530149212d64d4b69534716202659ef37ec8/tests/conftest.py#L20) branch
```
except RuntimeError as re:
    # CUDA-enabled Torch build, but no CUDA-capable device found
    if "Found no NVIDIA driver on your system" in str(re):
        pytest.skip("No NVIDIA driver found")
    raise
```

While `test_4bit_warnings` fails with `Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) were emitted`, as the error is catched by `pytest.warns`.