### PR TITLE
Fix CUDA 12.5 build issue

### DIFF
--- a/csrc/kernels.cu
+++ b/csrc/kernels.cu
@@ -12,8 +12,6 @@
 #include <cub/block/block_reduce.cuh>
 #include <cub/cub.cuh>
 #include <math_constants.h>
-#include <thrust/host_vector.h>
-#include <thrust/device_vector.h>
 #include <mma.h>
 
 

--- a/csrc/ops.cuh
+++ b/csrc/ops.cuh
@@ -19,10 +19,6 @@
 #include <vector>
 #include <functional>
 
-#include <thrust/host_vector.h>
-#include <thrust/device_vector.h>
-
-
 
 #define CUDA_CHECK_RETURN(value) {                      \
   cudaError_t _m_cudaStat = value;                    \


### PR DESCRIPTION
pythonInterface.cpp depends on ops.cuh
which in turn depends on some thrust headers.
It is defined as a C++ compilation unit
which is problematic  becuase thrift doesn't guarantee compatibility with a host compiler.

This is starting to cause compiler issues like this:
```
/usr/local/cuda/targets/x86_64-linux/include/cub/util_ptx.cuh:377:37: error: invalid output constraint '=f' in asm
    asm ("mul.rz.f32 %0, %1, %2;" : "=f"(d) : "f"(a), "f"(b));
                                    ^
/usr/local/cuda/targets/x86_64-linux/include/cub/util_ptx.cuh:388:41: error: invalid output constraint '=f' in asm
    asm ("fma.rz.f32 %0, %1, %2, %3;" : "=f"(d) : "f"(a), "f"(b), "f"(c));
                                        ^
/usr/local/cuda/targets/x86_64-linux/include/cub/util_ptx.cuh:415:39: error: use of undeclared identifier 'threadIdx'
    return ((block_dim_z == 1) ? 0 : (threadIdx.z * block_dim_x * block_dim_y)) +
                                      ^
/usr/local/cuda/targets/x86_64-linux/include/cub/util_ptx.cuh:416:40: error: use of undeclared identifier 'threadIdx'
            ((block_dim_y == 1) ? 0 : (threadIdx.y * block_dim_x)) +
                                       ^
/usr/local/cuda/targets/x86_64-linux/include/cub/util_ptx.cuh:417:13: error: use of undeclared identifier 'threadIdx'
            threadIdx.x;
```

A similar issue is being reported in https://github.com/NVIDIA/cccl/issues/1373 and https://forums.developer.nvidia.com/t/when-upgrade-from-cuda12-4-to-12-5-the-compilation-became-broken/295814 indicating that cuda 12.5 introduced some breaking changes here.

We don't actually depend on any symbols from the thrift headers, removing them in pythonInterface.cpp and kernels.cu fixes the issue