### PR TITLE
Fix Windows CUDA build compatibility with newest MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,9 +188,15 @@ if(WIN32)
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
-# Weird MSVC hacks
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2 /fp:fast")
+
+    # NVCC normally will only work with MSVC up to 1939.
+    # At this time, VS2022 17.10 starts using 1940.
+    # Workaround: use --allow-unsupported-compiler
+    if(BUILD_CUDA AND MSVC_VERSION VERSION_GREATER_EQUAL 1940)
+        string(APPEND CMAKE_CUDA_FLAGS " --allow-unsupported-compiler")
+    endif()
 endif()
 
 set_source_files_properties(${CPP_FILES} PROPERTIES LANGUAGE CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,13 @@ endif()
 
 
 if(BUILD_CUDA)
+    # NVCC normally will only work with MSVC up to 1939. VS2022 17.10+ starts using versions 1940+.
+    # Workaround: use --allow-unsupported-compiler
+    # This needs to be added *before* we try to enable the CUDA language so CMake's compiler check passes.
+    if(MSVC AND MSVC_VERSION VERSION_GREATER_EQUAL 1940)
+        string(APPEND CMAKE_CUDA_FLAGS " --allow-unsupported-compiler")
+    endif()
+
     enable_language(CUDA) # This will fail if CUDA is not found
     find_package(CUDAToolkit REQUIRED)
 
@@ -190,13 +197,6 @@ endif()
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2 /fp:fast")
-
-    # NVCC normally will only work with MSVC up to 1939.
-    # At this time, VS2022 17.10 starts using 1940.
-    # Workaround: use --allow-unsupported-compiler
-    if(BUILD_CUDA AND MSVC_VERSION VERSION_GREATER_EQUAL 1940)
-        string(APPEND CMAKE_CUDA_FLAGS " --allow-unsupported-compiler")
-    endif()
 endif()
 
 set_source_files_properties(${CPP_FILES} PROPERTIES LANGUAGE CXX)


### PR DESCRIPTION
A recent update to CI build image for Windows has broken the Windows CUDA builds. This is because the latest version of the Visual Studio compiler is version is v1940 [1]. For CUDA versions below 12.4, the check that `nvcc` uses for support is to only allow up to v193x [2]. The intent of that check is to support up to VS2022.

There's a change in CMake 3.29.4 for this when using the VS generator [3], but this PR will work around this in a similar way for older CMake versions and when using ninja.

cc: @Titus-von-Koeller 

**References**
[1] https://devblogs.microsoft.com/cppblog/msvc-toolset-minor-version-number-14-40-in-vs-2022-v17-10/
[2] https://github.com/pytorch/vision/pull/8492
[3] https://gitlab.kitware.com/cmake/cmake/-/issues/26003