### PR TITLE
Fixes for quant_storage and CPU offloading

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -282,10 +282,11 @@ class Params4bit(torch.nn.Parameter):
         self.compress_statistics = self.quant_state.nested
         self.quant_type = self.quant_state.quant_type
         self.bnb_quantized = True
+        self.quant_storage = torch.uint8  # We only support serialization with uint8 at the moment.
         return self
 
     def _quantize(self, device):
-        w = self.data.contiguous().cuda(device)
+        w = self.data.contiguous().to(device)
         w_4bit, quant_state = bnb.functional.quantize_4bit(
             w,
             blocksize=self.blocksize,
@@ -333,6 +334,7 @@ class Params4bit(torch.nn.Parameter):
                 blocksize=self.blocksize,
                 compress_statistics=self.compress_statistics,
                 quant_type=self.quant_type,
+                quant_storage=self.quant_storage,
             )
 
             return new_param
@@ -450,7 +452,7 @@ class Linear4bit(nn.Linear):
                 # since we registered the module, we can recover the state here
                 assert self.weight.shape[1] == 1
                 if not isinstance(self.weight, Params4bit):
-                    self.weight = Params4bit(self.weight, quant_storage=self.quant_storage)
+                    self.weight = Params4bit(self.weight, quant_storage=self.quant_storage, bnb_quantized=True)
                 self.weight.quant_state = self.quant_state
             else:
                 print(

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -283,7 +283,6 @@ class Params4bit(torch.nn.Parameter):
         self.quant_type = self.quant_state.quant_type
         self.bnb_quantized = True
 
-        # Note: uint8 is the default. TBD: Should this be in QuantState?
         self.quant_storage = data.dtype
 
         return self

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -284,7 +284,7 @@ class Params4bit(torch.nn.Parameter):
         self.bnb_quantized = True
 
         # Note: uint8 is the default. TBD: Should this be in QuantState?
-        self.quant_storage = torch.uint8
+        self.quant_storage = data.dtype
 
         return self
 

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -282,7 +282,10 @@ class Params4bit(torch.nn.Parameter):
         self.compress_statistics = self.quant_state.nested
         self.quant_type = self.quant_state.quant_type
         self.bnb_quantized = True
-        self.quant_storage = torch.uint8  # We only support serialization with uint8 at the moment.
+
+        # Note: uint8 is the default. TBD: Should this be in QuantState?
+        self.quant_storage = torch.uint8
+
         return self
 
     def _quantize(self, device):


### PR DESCRIPTION
This change ensures we don't lose track of a non-default `quant_storage` option or quantization state when moving between CPU and GPU.

cc: @Titus-von-Koeller @SunMarc 