### PR TITLE
add job to upload wheels to continuous pre-release

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -103,6 +103,7 @@ jobs:
           name: shared_library_cuda_${{ matrix.os }}_${{ matrix.arch }}_${{ matrix.cuda_version }}
           path: output/*
           retention-days: 7
+
   build-wheels:
     needs:
       - build-shared-libs
@@ -123,7 +124,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Download build artifact
+      - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true
@@ -163,27 +164,26 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:
-          pattern: "bdist_wheel_*/*.whl"
           path: wheels/
           merge-multiple: true
       - name: Inspect directory after downloading artifacts
-        run: ls -alFR
+        run: ls -alFR wheels/
       - name: Rename wheels
         run: |
-          for wheel in wheels/*.whl; do
-            if [[ $wheel == *linux*x86_64* ]]; then
+          find wheels/ -name '*.whl' -print0 | while IFS= read -r -d '' wheel; do
+            wheel_filename=$(basename "$wheel")
+            if [[ $wheel_filename == *linux*x86_64* ]]; then
               mv "$wheel" wheels/bnb-linux-x86_64.whl
-            elif [[ $wheel == *linux*aarch64* ]]; then
+            elif [[ $wheel_filename == *linux*aarch64* ]]; then
               mv "$wheel" wheels/bnb-linux-aarch64.whl
-            elif [[ $wheel == *macosx*x86_64* ]]; then
+            elif [[ $wheel_filename == *macosx*x86_64* ]]; then
               mv "$wheel" wheels/bnb-macos-x86_64.whl
-            elif [[ $wheel == *macosx*arm64* ]]; then
+            elif [[ $wheel_filename == *macosx*arm64* ]]; then
               mv "$wheel" wheels/bnb-macos-arm64.whl
-            elif [[ $wheel == *win*amd64* ]]; then
+            elif [[ $wheel_filename == *win*amd64* ]]; then
               mv "$wheel" wheels/bnb-windows-x86_64.whl
             else
-              echo "Unknown wheel format: $wheel"
-              # job should fail to alert maintainers to account for new wheel formats
+              echo "Unknown wheel format: $wheel_filename"
               exit 1
             fi
           done

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -161,16 +161,18 @@ jobs:
     needs:
       - build-wheels
     steps:
-      - name: Download wheels
+      - name: Download artifacts to tmp directory
         uses: actions/download-artifact@v4
         with:
-          path: wheels/
+          path: tmp/
+          pattern: "bdist_wheel_*"
           merge-multiple: true
-      - name: Inspect directory after downloading artifacts
-        run: ls -alFR wheels/
-      - name: Rename wheels
+      - name: Inspect tmp directory after downloading artifacts
+        run: ls -alFR tmp/
+      - name: Move and rename wheel files
         run: |
-          find wheels/ -name '*.whl' -print0 | while IFS= read -r -d '' wheel; do
+          mkdir -p wheels/
+          find tmp/ -type f -name '*.whl' -print0 | while IFS= read -r -d '' wheel; do
             wheel_filename=$(basename "$wheel")
             if [[ $wheel_filename == *linux*x86_64* ]]; then
               mv "$wheel" wheels/bnb-linux-x86_64.whl
@@ -187,15 +189,17 @@ jobs:
               exit 1
             fi
           done
+      - name: Inspect wheels directory after renaming files
+        run: ls -alFR wheels/
       - name: Create release and upload artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CONTINUOUS_RELEASE_TYPE: prerelease
           GITHUB_CONTINUOUS_RELEASE_TAG: continuous-release_main
         run: |
-            wget -q https://github.com/TheAssassin/pyuploadtool/releases/download/continuous/pyuploadtool-x86_64.AppImage
-            chmod +x pyuploadtool-x86_64.AppImage
-            ./pyuploadtool-x86_64.AppImage wheels/*
+          wget -q https://github.com/TheAssassin/pyuploadtool/releases/download/continuous/pyuploadtool-x86_64.AppImage
+          chmod +x pyuploadtool-x86_64.AppImage
+          ./pyuploadtool-x86_64.AppImage --appimage-extract-and-run wheels/*.whl
 
   audit-wheels:
     needs: build-wheels

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -154,6 +154,49 @@ jobs:
           path: dist/bitsandbytes-*.whl
           retention-days: 7
 
+  upload-pre-release-wheels:
+    name: Create release and upload artifacts
+    runs-on: ubuntu-latest
+    needs:
+      - build-wheels
+    steps:
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "bdist_wheel_*/*.whl"
+          path: wheels/
+          merge-multiple: true
+      - name: Inspect directory after downloading artifacts
+        run: ls -alFR
+      - name: Rename wheels
+        run: |
+          for wheel in wheels/*.whl; do
+            if [[ $wheel == *linux*x86_64* ]]; then
+              mv "$wheel" wheels/bnb-linux-x86_64.whl
+            elif [[ $wheel == *linux*aarch64* ]]; then
+              mv "$wheel" wheels/bnb-linux-aarch64.whl
+            elif [[ $wheel == *macosx*x86_64* ]]; then
+              mv "$wheel" wheels/bnb-macos-x86_64.whl
+            elif [[ $wheel == *macosx*arm64* ]]; then
+              mv "$wheel" wheels/bnb-macos-arm64.whl
+            elif [[ $wheel == *win*amd64* ]]; then
+              mv "$wheel" wheels/bnb-windows-x86_64.whl
+            else
+              echo "Unknown wheel format: $wheel"
+              # job should fail to alert maintainers to account for new wheel formats
+              exit 1
+            fi
+          done
+      - name: Create release and upload artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_CONTINUOUS_RELEASE_TYPE: prerelease
+          GITHUB_CONTINUOUS_RELEASE_TAG: continuous-release_main
+        run: |
+            wget -q https://github.com/TheAssassin/pyuploadtool/releases/download/continuous/pyuploadtool-x86_64.AppImage
+            chmod +x pyuploadtool-x86_64.AppImage
+            ./pyuploadtool-x86_64.AppImage wheels/*
+
   audit-wheels:
     needs: build-wheels
     runs-on: ubuntu-latest


### PR DESCRIPTION
After plenty of discussion around different ways of making pre-built wheels available for preview, I'm trying out an approach that seems the most promising so far.

I'm starting simple to try things out and iterate from there, but the idea is that we can have multiple 'continuous' pre-releases. In practice this means that we're using `pyuploadtool` which I came across towards the end of my extensive research to create and consequently keep updating pre-releases and their assets.

I spent quite some time with another approach that would have allowed users to download the artifacts of a branch, unzip them, install the wheel. However that approach needs a PAT to access the wheels, sth that became apparent too late (the GH docs seem to say sth else...).

Anyways, this approach doesn't have that problem, as (pre-)release assets are globally readable without rate limit or needing to be logged in (PAT). We can also attach the wheels directly, meaning there's no intermediate zip to unpack:

Therefore users will simply be able to install via sth like 

`pip install https://github.com/bitsandbytes-foundation/bitsandbytes/releases/download/continuous-build_multi-backend-refactor/bnb-linux-x86_64.whl`