### PR TITLE
Edenzzzz's fix for min_8bit_size functionality in Optimizer base classes

### DIFF
--- a/bitsandbytes/optim/optimizer.py
+++ b/bitsandbytes/optim/optimizer.py
@@ -437,7 +437,7 @@ class Optimizer2State(Optimizer8bit):
         state = self.state[p]
         state["step"] = 0
 
-        if dtype == torch.float32 or (dtype == torch.uint8 and p.numel() < 4096):
+        if dtype == torch.float32:
             state["state1"] = self.get_state_buffer(p, dtype=torch.float32)
             state["state2"] = self.get_state_buffer(p, dtype=torch.float32)
         elif dtype == torch.uint8:

--- a/bitsandbytes/optim/optimizer.py
+++ b/bitsandbytes/optim/optimizer.py
@@ -656,7 +656,7 @@ class Optimizer1State(Optimizer8bit):
         state = self.state[p]
         state["step"] = 0
 
-        if dtype == torch.float32 or (dtype == torch.uint8 and p.numel() < 4096):
+        if dtype == torch.float32:
             state["state1"] = self.get_state_buffer(p, dtype=torch.float32)
         elif dtype == torch.uint8:
             if state["step"] == 0:


### PR DESCRIPTION
This PR supersedes and closes #123.

I couldn't push to Edenzzzz's branch as he used the `main` branch and that had branch protection rules applied. So I couldn't continue in that PR as we need to release by the end of the day and want to include this valuable change.

Thanks @Edenzzzz for providing this fix, I just had to apply the same to the other optimizer base class.