### PR TITLE
[FSDP] Enable loading prequantized weights with bf16/fp16/fp32 quant_storage

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -273,6 +273,7 @@ class Params4bit(torch.nn.Parameter):
         quantized_stats: Dict[str, Any],
         requires_grad: bool = False,
         device="cuda",
+        module: Optional["Linear4bit"] = None,
         **kwargs,
     ) -> "Params4bit":
         self = torch.Tensor._make_subclass(cls, data.to(device))
@@ -284,6 +285,10 @@ class Params4bit(torch.nn.Parameter):
         self.bnb_quantized = True
 
         self.quant_storage = data.dtype
+        self.module = module
+
+        if self.module is not None:
+            self.module.quant_state = self.quant_state
 
         return self
 


### PR DESCRIPTION
This is a companion PR for https://github.com/huggingface/transformers/pull/32276 to allow us to load prequantized weights with alternate storage. We keep track of metadata we need the same way we would with `Params4bit.__new__` after PR #970.

This works with models exported with a non-default `quant_storage` such as [this one in NF4 with BF16 storage](https://huggingface.co/hugging-quants/Meta-Llama-3.1-405B-BNB-NF4-BF16).

@Titus-von-Koeller
@winglian