### PR TITLE
AdamE optimizer with decoupled L1 and L2 regularization

### DIFF
--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -1534,6 +1534,7 @@ def optimizer_update_32bit(
     lr: float,
     state2: Optional[torch.Tensor] = None,
     beta2: float = 0.0,
+    lasso: float = 0.0,
     weight_decay: float = 0.0,
     gnorm_scale: float = 1.0,
     unorm_vec: Optional[torch.Tensor] = None,
@@ -1559,6 +1560,8 @@ def optimizer_update_32bit(
         Optimizer beta1.
     eps : float
         Optimizer epsilon.
+    lasso : float
+        Lasso regularization coefficient.
     weight_decay : float
         Weight decay.
     step : int
@@ -1608,6 +1611,7 @@ def optimizer_update_32bit(
         ct.c_float(beta1),
         ct.c_float(beta2),
         ct.c_float(eps),
+        ct.c_float(lasso),
         ct.c_float(weight_decay),
         ct.c_int32(step),
         ct.c_float(lr),
@@ -1635,6 +1639,7 @@ def optimizer_update_8bit(
     max2: Optional[torch.Tensor],
     new_max1: Tensor,
     new_max2: Optional[torch.Tensor],
+    lasso: float = 0.0,
     weight_decay: float = 0.0,
     gnorm_scale: float = 1.0,
     unorm_vec: Optional[torch.Tensor] = None,
@@ -1664,6 +1669,8 @@ def optimizer_update_8bit(
         Adam beta2.
     eps : float
         Adam epsilon.
+    lasso : float
+        Lasso regularization coefficient.
     weight_decay : float
         Weight decay.
     step : int
@@ -1716,6 +1723,7 @@ def optimizer_update_8bit(
             get_ptr(max2),
             get_ptr(new_max1),
             get_ptr(new_max2),
+            ct.c_float(lasso),
             ct.c_float(weight_decay),
             ct.c_float(gnorm_scale),
             ct.c_int32(g.numel()),
@@ -1740,6 +1748,7 @@ def optimizer_update_8bit(
             get_ptr(max2),
             get_ptr(new_max1),
             get_ptr(new_max2),
+            ct.c_float(lasso),
             ct.c_float(weight_decay),
             ct.c_float(gnorm_scale),
             ct.c_int32(g.numel()),
@@ -1766,6 +1775,7 @@ def optimizer_update_8bit_blockwise(
     qmap2: Optional[torch.Tensor],
     absmax1: Tensor,
     absmax2: Optional[torch.Tensor],
+    lasso: float = 0.0,
     weight_decay: float = 0.0,
     gnorm_scale: float = 1.0,
     skip_zeros=False,
@@ -1806,6 +1816,7 @@ def optimizer_update_8bit_blockwise(
         get_ptr(qmap2),
         get_ptr(absmax1),
         get_ptr(absmax2),
+        ct.c_float(lasso),
         ct.c_float(weight_decay),
         ct.c_float(gnorm_scale),
         ct.c_bool(skip_zeros),

--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -1536,6 +1536,7 @@ def optimizer_update_32bit(
     beta2: float = 0.0,
     lasso: float = 0.0,
     weight_decay: float = 0.0,
+    lr_reg: Optional[float] = None,
     gnorm_scale: float = 1.0,
     unorm_vec: Optional[torch.Tensor] = None,
     max_unorm: float = 0.0,
@@ -1568,6 +1569,8 @@ def optimizer_update_32bit(
         Current optimizer step.
     lr : float
         The learning rate.
+    lr_reg (`float`, defaults to None):
+        The constant learning rate to use with the regularization components (if left None uses current lr at each step).
     state2 : torch.Tensor
         Optimizer state 2.
     beta2 : float
@@ -1615,6 +1618,7 @@ def optimizer_update_32bit(
         ct.c_float(weight_decay),
         ct.c_int32(step),
         ct.c_float(lr),
+        ct.c_float(lr_reg if lr_reg is not None else lr),
         ct.c_float(gnorm_scale),
         ct.c_bool(skip_zeros),
         ct.c_int32(g.numel()),
@@ -1641,6 +1645,7 @@ def optimizer_update_8bit(
     new_max2: Optional[torch.Tensor],
     lasso: float = 0.0,
     weight_decay: float = 0.0,
+    lr_reg: Optional[float] = None,
     gnorm_scale: float = 1.0,
     unorm_vec: Optional[torch.Tensor] = None,
     max_unorm: float = 0.0,
@@ -1677,6 +1682,8 @@ def optimizer_update_8bit(
         Current optimizer step.
     lr : float
         The learning rate.
+    lr_reg (`float`, defaults to None):
+        The constant learning rate to use with the regularization components (if left None uses current lr at each step).
     qmap1 : torch.Tensor
         Quantization map for first Adam state.
     qmap2 : torch.Tensor
@@ -1717,6 +1724,7 @@ def optimizer_update_8bit(
             ct.c_float(eps),
             ct.c_int32(step),
             ct.c_float(lr),
+            ct.c_float(lr_reg if lr_reg is not None else lr),
             get_ptr(qmap1),
             get_ptr(qmap2),
             get_ptr(max1),
@@ -1742,6 +1750,7 @@ def optimizer_update_8bit(
             ct.c_float(eps),
             ct.c_int32(step),
             ct.c_float(lr),
+            ct.c_float(lr_reg if lr_reg is not None else lr),
             get_ptr(qmap1),
             get_ptr(qmap2),
             get_ptr(max1),
@@ -1777,6 +1786,7 @@ def optimizer_update_8bit_blockwise(
     absmax2: Optional[torch.Tensor],
     lasso: float = 0.0,
     weight_decay: float = 0.0,
+    lr_reg: Optional[float] = None,
     gnorm_scale: float = 1.0,
     skip_zeros=False,
 ) -> None:
@@ -1812,6 +1822,7 @@ def optimizer_update_8bit_blockwise(
         ct.c_float(eps),
         ct.c_int32(step),
         ct.c_float(lr),
+        ct.c_float(lr_reg if lr_reg is not None else lr),
         get_ptr(qmap1),
         get_ptr(qmap2),
         get_ptr(absmax1),

--- a/bitsandbytes/optim/__init__.py
+++ b/bitsandbytes/optim/__init__.py
@@ -5,6 +5,14 @@
 
 from .adagrad import Adagrad, Adagrad8bit, Adagrad32bit
 from .adam import Adam, Adam8bit, Adam32bit, PagedAdam, PagedAdam8bit, PagedAdam32bit
+from .adame import (
+    AdamE,
+    AdamE8bit,
+    AdamE32bit,
+    PagedAdamE,
+    PagedAdamE8bit,
+    PagedAdamE32bit,
+)
 from .adamw import (
     AdamW,
     AdamW8bit,

--- a/bitsandbytes/optim/adame.py
+++ b/bitsandbytes/optim/adame.py
@@ -1,0 +1,397 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from bitsandbytes.optim.optimizer import Optimizer2State
+
+class AdamE(Optimizer2State):
+    def __init__(
+        self,
+        params,
+        lr=1e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        lasso=1e-2,
+        weight_decay=1e-2,
+        amsgrad=False,
+        optim_bits=32,
+        args=None,
+        min_8bit_size=4096,
+        percentile_clipping=100,
+        block_wise=True,
+        is_paged=False,
+    ):
+        """
+        Base AdamE optimizer.
+        This is a variant of the Adam optimizer implementing decoupled Lasso and Weight Decay regularisation,
+        resulting in an Elastic Net regularization.
+        The two regularizations are independent one of the other and can be switched off at will setting their coefficient to 0.
+
+        (Developer's note: the name "AdamE" is pronounced as the French word "madame" without the initial 'm';
+        I have never been good in French classes, but the name sounds nice)
+
+        Arguments:
+            params (`torch.tensor`):
+                The input parameters to optimize.
+            lr (`float`, defaults to 1e-3):
+                The learning rate.
+            betas (`tuple(float, float)`, defaults to (0.9, 0.999)):
+                The beta values are the decay rates of the first and second-order moment of the optimizer.
+            eps (`float`, defaults to 1e-8):
+                The epsilon value prevents division by zero in the optimizer.
+            lasso (`float`, defaults to 1e-2):
+                The lasso regularization coefficient value for the optimizer.
+            weight_decay (`float`, defaults to 1e-2):
+                The weight decay value for the optimizer.
+            amsgrad (`bool`, defaults to `False`):
+                Whether to use the [AMSGrad](https://hf.co/papers/1904.09237) variant of Adam that uses the maximum of past squared gradients instead.
+            optim_bits (`int`, defaults to 32):
+                The number of bits of the optimizer state.
+            args (`object`, defaults to `None`):
+                An object with additional arguments.
+            min_8bit_size (`int`, defaults to 4096):
+                The minimum number of elements of the parameter tensors for 8-bit optimization.
+            percentile_clipping (`int`, defaults to 100):
+                Adapts clipping threshold automatically by tracking the last 100 gradient norms and clipping the gradient at a certain percentile to improve stability.
+            block_wise (`bool`, defaults to `True`):
+                Whether to independently quantize each block of tensors to reduce outlier effects and improve stability.
+            is_paged (`bool`, defaults to `False`):
+                Whether the optimizer is a paged optimizer or not.
+        """
+        super().__init__(
+            "adam",
+            params,
+            lr,
+            betas,
+            eps,
+            lasso,
+            weight_decay,
+            optim_bits,
+            args,
+            min_8bit_size,
+            percentile_clipping,
+            block_wise,
+            is_paged=is_paged,
+        )
+
+
+class AdamE8bit(Optimizer2State):
+    def __init__(
+        self,
+        params,
+        lr=1e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        lasso=1e-2,
+        weight_decay=1e-2,
+        amsgrad=False,
+        optim_bits=32,
+        args=None,
+        min_8bit_size=4096,
+        percentile_clipping=100,
+        block_wise=True,
+        is_paged=False,
+    ):
+        """
+        8-bit AdamE optimizer.
+
+        Arguments:
+            params (`torch.tensor`):
+                The input parameters to optimize.
+            lr (`float`, defaults to 1e-3):
+                The learning rate.
+            betas (`tuple(float, float)`, defaults to (0.9, 0.999)):
+                The beta values are the decay rates of the first and second-order moment of the optimizer.
+            eps (`float`, defaults to 1e-8):
+                The epsilon value prevents division by zero in the optimizer.
+            lasso (`float`, defaults to 1e-2):
+                The lasso regularization coefficient value for the optimizer.
+            weight_decay (`float`, defaults to 1e-2):
+                The weight decay value for the optimizer.
+            amsgrad (`bool`, defaults to `False`):
+                Whether to use the [AMSGrad](https://hf.co/papers/1904.09237) variant of Adam that uses the maximum of past squared gradients instead.
+            optim_bits (`int`, defaults to 32):
+                The number of bits of the optimizer state.
+            args (`object`, defaults to `None`):
+                An object with additional arguments.
+            min_8bit_size (`int`, defaults to 4096):
+                The minimum number of elements of the parameter tensors for 8-bit optimization.
+            percentile_clipping (`int`, defaults to 100):
+                Adapts clipping threshold automatically by tracking the last 100 gradient norms and clipping the gradient at a certain percentile to improve stability.
+            block_wise (`bool`, defaults to `True`):
+                Whether to independently quantize each block of tensors to reduce outlier effects and improve stability.
+            is_paged (`bool`, defaults to `False`):
+                Whether the optimizer is a paged optimizer or not.
+        """
+        super().__init__(
+            "adam",
+            params,
+            lr,
+            betas,
+            eps,
+            lasso,
+            weight_decay,
+            8,
+            args,
+            min_8bit_size,
+            percentile_clipping,
+            block_wise,
+            is_paged=is_paged,
+        )
+
+
+class AdamE32bit(Optimizer2State):
+    def __init__(
+        self,
+        params,
+        lr=1e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        lasso=1e-2,
+        weight_decay=1e-2,
+        amsgrad=False,
+        optim_bits=32,
+        args=None,
+        min_8bit_size=4096,
+        percentile_clipping=100,
+        block_wise=True,
+        is_paged=False,
+    ):
+        """
+        32-bit AdamE optimizer.
+
+        Arguments:
+            params (`torch.tensor`):
+                The input parameters to optimize.
+            lr (`float`, defaults to 1e-3):
+                The learning rate.
+            betas (`tuple(float, float)`, defaults to (0.9, 0.999)):
+                The beta values are the decay rates of the first and second-order moment of the optimizer.
+            eps (`float`, defaults to 1e-8):
+                The epsilon value prevents division by zero in the optimizer.
+            lasso (`float`, defaults to 1e-2):
+                The lasso regularization coefficient value for the optimizer.
+            weight_decay (`float`, defaults to 1e-2):
+                The weight decay value for the optimizer.
+            amsgrad (`bool`, defaults to `False`):
+                Whether to use the [AMSGrad](https://hf.co/papers/1904.09237) variant of Adam that uses the maximum of past squared gradients instead.
+            optim_bits (`int`, defaults to 32):
+                The number of bits of the optimizer state.
+            args (`object`, defaults to `None`):
+                An object with additional arguments.
+            min_8bit_size (`int`, defaults to 4096):
+                The minimum number of elements of the parameter tensors for 8-bit optimization.
+            percentile_clipping (`int`, defaults to 100):
+                Adapts clipping threshold automatically by tracking the last 100 gradient norms and clipping the gradient at a certain percentile to improve stability.
+            block_wise (`bool`, defaults to `True`):
+                Whether to independently quantize each block of tensors to reduce outlier effects and improve stability.
+            is_paged (`bool`, defaults to `False`):
+                Whether the optimizer is a paged optimizer or not.
+        """
+        super().__init__(
+            "adam",
+            params,
+            lr,
+            betas,
+            eps,
+            lasso,
+            weight_decay,
+            32,
+            args,
+            min_8bit_size,
+            percentile_clipping,
+            block_wise,
+            is_paged=is_paged,
+        )
+
+
+class PagedAdamE(Optimizer2State):
+    def __init__(
+        self,
+        params,
+        lr=1e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        lasso=1e-2,
+        weight_decay=1e-2,
+        amsgrad=False,
+        optim_bits=32,
+        args=None,
+        min_8bit_size=4096,
+        percentile_clipping=100,
+        block_wise=True,
+    ):
+        """
+        Paged AdamE optimizer.
+
+        Arguments:
+            params (`torch.tensor`):
+                The input parameters to optimize.
+            lr (`float`, defaults to 1e-3):
+                The learning rate.
+            betas (`tuple(float, float)`, defaults to (0.9, 0.999)):
+                The beta values are the decay rates of the first and second-order moment of the optimizer.
+            eps (`float`, defaults to 1e-8):
+                The epsilon value prevents division by zero in the optimizer.
+            lasso (`float`, defaults to 1e-2):
+                The lasso regularization coefficient value for the optimizer.
+            weight_decay (`float`, defaults to 1e-2):
+                The weight decay value for the optimizer.
+            amsgrad (`bool`, defaults to `False`):
+                Whether to use the [AMSGrad](https://hf.co/papers/1904.09237) variant of Adam that uses the maximum of past squared gradients instead.
+            optim_bits (`int`, defaults to 32):
+                The number of bits of the optimizer state.
+            args (`object`, defaults to `None`):
+                An object with additional arguments.
+            min_8bit_size (`int`, defaults to 4096):
+                The minimum number of elements of the parameter tensors for 8-bit optimization.
+            percentile_clipping (`int`, defaults to 100):
+                Adapts clipping threshold automatically by tracking the last 100 gradient norms and clipping the gradient at a certain percentile to improve stability.
+            block_wise (`bool`, defaults to `True`):
+                Whether to independently quantize each block of tensors to reduce outlier effects and improve stability.
+            is_paged (`bool`, defaults to `False`):
+                Whether the optimizer is a paged optimizer or not.
+        """
+        super().__init__(
+            "adam",
+            params,
+            lr,
+            betas,
+            eps,
+            lasso,
+            weight_decay,
+            optim_bits,
+            args,
+            min_8bit_size,
+            percentile_clipping,
+            block_wise,
+            is_paged=True,
+        )
+
+
+class PagedAdamE8bit(Optimizer2State):
+    def __init__(
+        self,
+        params,
+        lr=1e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        lasso=1e-2,
+        weight_decay=1e-2,
+        amsgrad=False,
+        optim_bits=32,
+        args=None,
+        min_8bit_size=4096,
+        percentile_clipping=100,
+        block_wise=True,
+    ):
+        """
+        Paged 8-bit AdamE optimizer.
+
+        Arguments:
+            params (`torch.tensor`):
+                The input parameters to optimize.
+            lr (`float`, defaults to 1e-3):
+                The learning rate.
+            betas (`tuple(float, float)`, defaults to (0.9, 0.999)):
+                The beta values are the decay rates of the first and second-order moment of the optimizer.
+            eps (`float`, defaults to 1e-8):
+                The epsilon value prevents division by zero in the optimizer.
+            lasso (`float`, defaults to 1e-2):
+                The lasso regularization coefficient value for the optimizer.
+            weight_decay (`float`, defaults to 1e-2):
+                The weight decay value for the optimizer.
+            amsgrad (`bool`, defaults to `False`):
+                Whether to use the [AMSGrad](https://hf.co/papers/1904.09237) variant of Adam that uses the maximum of past squared gradients instead.
+            optim_bits (`int`, defaults to 32):
+                The number of bits of the optimizer state.
+            args (`object`, defaults to `None`):
+                An object with additional arguments.
+            min_8bit_size (`int`, defaults to 4096):
+                The minimum number of elements of the parameter tensors for 8-bit optimization.
+            percentile_clipping (`int`, defaults to 100):
+                Adapts clipping threshold automatically by tracking the last 100 gradient norms and clipping the gradient at a certain percentile to improve stability.
+            block_wise (`bool`, defaults to `True`):
+                Whether to independently quantize each block of tensors to reduce outlier effects and improve stability.
+            is_paged (`bool`, defaults to `False`):
+                Whether the optimizer is a paged optimizer or not.
+        """
+        super().__init__(
+            "adam",
+            params,
+            lr,
+            betas,
+            eps,
+            lasso,
+            weight_decay,
+            8,
+            args,
+            min_8bit_size,
+            percentile_clipping,
+            block_wise,
+            is_paged=True,
+        )
+
+
+class PagedAdamE32bit(Optimizer2State):
+    def __init__(
+        self,
+        params,
+        lr=1e-3,
+        betas=(0.9, 0.999),
+        eps=1e-8,
+        lasso=1e-2,
+        weight_decay=1e-2,
+        amsgrad=False,
+        optim_bits=32,
+        args=None,
+        min_8bit_size=4096,
+        percentile_clipping=100,
+        block_wise=True,
+    ):
+        """
+        Paged 32-bit AdamE optimizer.
+
+        Arguments:
+            params (`torch.tensor`):
+                The input parameters to optimize.
+            lr (`float`, defaults to 1e-3):
+                The learning rate.
+            betas (`tuple(float, float)`, defaults to (0.9, 0.999)):
+                The beta values are the decay rates of the first and second-order moment of the optimizer.
+            eps (`float`, defaults to 1e-8):
+                The epsilon value prevents division by zero in the optimizer.
+            lasso (`float`, defaults to 1e-2):
+                The lasso regularization coefficient value for the optimizer.
+            weight_decay (`float`, defaults to 1e-2):
+                The weight decay value for the optimizer.
+            amsgrad (`bool`, defaults to `False`):
+                Whether to use the [AMSGrad](https://hf.co/papers/1904.09237) variant of Adam that uses the maximum of past squared gradients instead.
+            optim_bits (`int`, defaults to 32):
+                The number of bits of the optimizer state.
+            args (`object`, defaults to `None`):
+                An object with additional arguments.
+            min_8bit_size (`int`, defaults to 4096):
+                The minimum number of elements of the parameter tensors for 8-bit optimization.
+            percentile_clipping (`int`, defaults to 100):
+                Adapts clipping threshold automatically by tracking the last 100 gradient norms and clipping the gradient at a certain percentile to improve stability.
+            block_wise (`bool`, defaults to `True`):
+                Whether to independently quantize each block of tensors to reduce outlier effects and improve stability.
+            is_paged (`bool`, defaults to `False`):
+                Whether the optimizer is a paged optimizer or not.
+        """
+        super().__init__(
+            "adam",
+            params,
+            lr,
+            betas,
+            eps,
+            lasso,
+            weight_decay,
+            32,
+            args,
+            min_8bit_size,
+            percentile_clipping,
+            block_wise,
+            is_paged=True,
+        )

--- a/bitsandbytes/optim/adame.py
+++ b/bitsandbytes/optim/adame.py
@@ -13,6 +13,7 @@ class AdamE(Optimizer2State):
         eps=1e-8,
         lasso=1e-2,
         weight_decay=1e-2,
+        lr_reg=None,
         amsgrad=False,
         optim_bits=32,
         args=None,
@@ -43,6 +44,8 @@ class AdamE(Optimizer2State):
                 The lasso regularization coefficient value for the optimizer.
             weight_decay (`float`, defaults to 1e-2):
                 The weight decay value for the optimizer.
+            lr_reg (`float`, defaults to None):
+                The constant learning rate to use with the regularization components; if left to None the current lr of the parameter group will be used.
             amsgrad (`bool`, defaults to `False`):
                 Whether to use the [AMSGrad](https://hf.co/papers/1904.09237) variant of Adam that uses the maximum of past squared gradients instead.
             optim_bits (`int`, defaults to 32):
@@ -66,6 +69,7 @@ class AdamE(Optimizer2State):
             eps,
             lasso,
             weight_decay,
+            lr_reg,
             optim_bits,
             args,
             min_8bit_size,
@@ -84,6 +88,7 @@ class AdamE8bit(Optimizer2State):
         eps=1e-8,
         lasso=1e-2,
         weight_decay=1e-2,
+        lr_reg=None,
         amsgrad=False,
         optim_bits=32,
         args=None,
@@ -108,6 +113,8 @@ class AdamE8bit(Optimizer2State):
                 The lasso regularization coefficient value for the optimizer.
             weight_decay (`float`, defaults to 1e-2):
                 The weight decay value for the optimizer.
+            lr_reg (`float`, defaults to None):
+                The constant learning rate to use with the regularization components; if left to None the current lr of the parameter group will be used.
             amsgrad (`bool`, defaults to `False`):
                 Whether to use the [AMSGrad](https://hf.co/papers/1904.09237) variant of Adam that uses the maximum of past squared gradients instead.
             optim_bits (`int`, defaults to 32):
@@ -131,6 +138,7 @@ class AdamE8bit(Optimizer2State):
             eps,
             lasso,
             weight_decay,
+            lr_reg,
             8,
             args,
             min_8bit_size,
@@ -149,6 +157,7 @@ class AdamE32bit(Optimizer2State):
         eps=1e-8,
         lasso=1e-2,
         weight_decay=1e-2,
+        lr_reg=None,
         amsgrad=False,
         optim_bits=32,
         args=None,
@@ -173,6 +182,8 @@ class AdamE32bit(Optimizer2State):
                 The lasso regularization coefficient value for the optimizer.
             weight_decay (`float`, defaults to 1e-2):
                 The weight decay value for the optimizer.
+            lr_reg (`float`, defaults to None):
+                The constant learning rate to use with the regularization components; if left to None the current lr of the parameter group will be used.
             amsgrad (`bool`, defaults to `False`):
                 Whether to use the [AMSGrad](https://hf.co/papers/1904.09237) variant of Adam that uses the maximum of past squared gradients instead.
             optim_bits (`int`, defaults to 32):
@@ -196,6 +207,7 @@ class AdamE32bit(Optimizer2State):
             eps,
             lasso,
             weight_decay,
+            lr_reg,
             32,
             args,
             min_8bit_size,
@@ -214,6 +226,7 @@ class PagedAdamE(Optimizer2State):
         eps=1e-8,
         lasso=1e-2,
         weight_decay=1e-2,
+        lr_reg=None,
         amsgrad=False,
         optim_bits=32,
         args=None,
@@ -237,6 +250,8 @@ class PagedAdamE(Optimizer2State):
                 The lasso regularization coefficient value for the optimizer.
             weight_decay (`float`, defaults to 1e-2):
                 The weight decay value for the optimizer.
+            lr_reg (`float`, defaults to None):
+                The constant learning rate to use with the regularization components; if left to None the current lr of the parameter group will be used.
             amsgrad (`bool`, defaults to `False`):
                 Whether to use the [AMSGrad](https://hf.co/papers/1904.09237) variant of Adam that uses the maximum of past squared gradients instead.
             optim_bits (`int`, defaults to 32):
@@ -260,6 +275,7 @@ class PagedAdamE(Optimizer2State):
             eps,
             lasso,
             weight_decay,
+            lr_reg,
             optim_bits,
             args,
             min_8bit_size,
@@ -278,6 +294,7 @@ class PagedAdamE8bit(Optimizer2State):
         eps=1e-8,
         lasso=1e-2,
         weight_decay=1e-2,
+        lr_reg=None,
         amsgrad=False,
         optim_bits=32,
         args=None,
@@ -301,6 +318,8 @@ class PagedAdamE8bit(Optimizer2State):
                 The lasso regularization coefficient value for the optimizer.
             weight_decay (`float`, defaults to 1e-2):
                 The weight decay value for the optimizer.
+            lr_reg (`float`, defaults to None):
+                The constant learning rate to use with the regularization components; if left to None the current lr of the parameter group will be used.
             amsgrad (`bool`, defaults to `False`):
                 Whether to use the [AMSGrad](https://hf.co/papers/1904.09237) variant of Adam that uses the maximum of past squared gradients instead.
             optim_bits (`int`, defaults to 32):
@@ -324,6 +343,7 @@ class PagedAdamE8bit(Optimizer2State):
             eps,
             lasso,
             weight_decay,
+            lr_reg,
             8,
             args,
             min_8bit_size,
@@ -342,6 +362,7 @@ class PagedAdamE32bit(Optimizer2State):
         eps=1e-8,
         lasso=1e-2,
         weight_decay=1e-2,
+        lr_reg=None,
         amsgrad=False,
         optim_bits=32,
         args=None,
@@ -365,6 +386,8 @@ class PagedAdamE32bit(Optimizer2State):
                 The lasso regularization coefficient value for the optimizer.
             weight_decay (`float`, defaults to 1e-2):
                 The weight decay value for the optimizer.
+            lr_reg (`float`, defaults to None):
+                The constant learning rate to use with the regularization components; if left to None the current lr of the parameter group will be used.
             amsgrad (`bool`, defaults to `False`):
                 Whether to use the [AMSGrad](https://hf.co/papers/1904.09237) variant of Adam that uses the maximum of past squared gradients instead.
             optim_bits (`int`, defaults to 32):
@@ -388,6 +411,7 @@ class PagedAdamE32bit(Optimizer2State):
             eps,
             lasso,
             weight_decay,
+            lr_reg,
             32,
             args,
             min_8bit_size,

--- a/bitsandbytes/optim/optimizer.py
+++ b/bitsandbytes/optim/optimizer.py
@@ -300,6 +300,7 @@ class Optimizer8bit(torch.optim.Optimizer):
         config["lasso"] = group["lasso"]
         config["weight_decay"] = group["weight_decay"]
         config["lr"] = group["lr"]
+        config["lr_reg"] = group["lr_reg"]
         config["optim_bits"] = self.args.optim_bits
         config["min_8bit_size"] = self.args.min_8bit_size
         config["percentile_clipping"] = self.args.percentile_clipping
@@ -348,6 +349,7 @@ class Optimizer2State(Optimizer8bit):
         eps=1e-8,
         lasso=0.0,
         weight_decay=0.0,
+        lr_reg=None,
         optim_bits=32,
         args=None,
         min_8bit_size=4096,
@@ -375,6 +377,8 @@ class Optimizer2State(Optimizer8bit):
                 The lasso regularization coefficient value for the optimizer.
             weight_decay (`float`, defaults to 0.0):
                 The weight decay value for the optimizer.
+            lr_reg (`float`, defaults to None):
+                The constant learning rate to use with the regularization components; if left to None the current lr of the parameter group will be used.
             optim_bits (`int`, defaults to 32):
                 The number of bits of the optimizer state.
             args (`object`, defaults to `None`):
@@ -407,7 +411,9 @@ class Optimizer2State(Optimizer8bit):
             raise ValueError(f"Invalid lasso regularization coefficient value: {lasso}")
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
-        defaults = dict(lr=lr, betas=betas, eps=eps, lasso=lasso, weight_decay=weight_decay)
+        if lr_reg is not None and not 0.0 <= lr_reg:
+            raise ValueError(f"Invalid lr_reg value: {lr_reg}")
+        defaults = dict(lr=lr, betas=betas, eps=eps, lasso=lasso, weight_decay=weight_decay, lr_reg=lr_reg)
         super().__init__(params, defaults, optim_bits, is_paged)
 
         if args is None:
@@ -516,6 +522,7 @@ class Optimizer2State(Optimizer8bit):
                 config["betas"][1],
                 config["lasso"],
                 config["weight_decay"],
+                config["lr_reg"],
                 gnorm_scale,
                 state["unorm_vec"] if config["max_unorm"] > 0.0 else None,
                 max_unorm=config["max_unorm"],
@@ -542,6 +549,7 @@ class Optimizer2State(Optimizer8bit):
                 state["new_max2"],
                 config["lasso"],
                 config["weight_decay"],
+                config["lr_reg"],
                 gnorm_scale=gnorm_scale,
                 unorm_vec=state["unorm_vec"] if config["max_unorm"] > 0.0 else None,
                 max_unorm=config["max_unorm"],
@@ -568,6 +576,7 @@ class Optimizer2State(Optimizer8bit):
                 state["absmax2"],
                 config["lasso"],
                 config["weight_decay"],
+                config["lr_reg"],
                 gnorm_scale=gnorm_scale,
                 skip_zeros=config["skip_zeros"],
             )
@@ -583,6 +592,7 @@ class Optimizer1State(Optimizer8bit):
         eps=1e-8,
         lasso=0.0,
         weight_decay=0.0,
+        lr_reg=None,
         optim_bits=32,
         args=None,
         min_8bit_size=4096,
@@ -610,6 +620,8 @@ class Optimizer1State(Optimizer8bit):
                 The lasso regularization coefficient value for the optimizer.
             weight_decay (`float`, defaults to 0.0):
                 The weight decay value for the optimizer.
+            lr_reg (`float`, defaults to None):
+                The constant learning rate to use with the regularization components; if left to None the current lr of the parameter group will be used.
             optim_bits (`int`, defaults to 32):
                 The number of bits of the optimizer state.
             args (`object`, defaults to `None`):
@@ -638,7 +650,9 @@ class Optimizer1State(Optimizer8bit):
             raise ValueError(f"Invalid lasso regularization coefficient value: {lasso}")
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
-        defaults = dict(lr=lr, betas=betas, eps=eps, lasso=lasso, weight_decay=weight_decay)
+        if lr_reg is not None and not 0.0 <= lr_reg:
+            raise ValueError(f"Invalid lr_reg value: {lr_reg}")
+        defaults = dict(lr=lr, betas=betas, eps=eps, lasso=lasso, weight_decay=weight_decay, lr_reg=lr_reg)
         super().__init__(params, defaults, optim_bits, is_paged)
 
         if args is None:
@@ -739,6 +753,7 @@ class Optimizer1State(Optimizer8bit):
                 config["betas"][1],
                 config["lasso"],
                 config["weight_decay"],
+                config["lr_reg"],
                 gnorm_scale,
                 state["unorm_vec"] if config["max_unorm"] > 0.0 else None,
                 max_unorm=config["max_unorm"],
@@ -765,6 +780,7 @@ class Optimizer1State(Optimizer8bit):
                 None,
                 config["lasso"],
                 config["weight_decay"],
+                config["lr_reg"],
                 gnorm_scale,
                 state["unorm_vec"] if config["max_unorm"] > 0.0 else None,
                 max_unorm=config["max_unorm"],
@@ -789,6 +805,7 @@ class Optimizer1State(Optimizer8bit):
                 None,
                 config["lasso"],
                 config["weight_decay"],
+                config["lr_reg"],
                 gnorm_scale=gnorm_scale,
                 skip_zeros=config["skip_zeros"],
             )

--- a/bitsandbytes/optim/optimizer.py
+++ b/bitsandbytes/optim/optimizer.py
@@ -297,6 +297,7 @@ class Optimizer8bit(torch.optim.Optimizer):
         config = {}
         config["betas"] = group["betas"]
         config["eps"] = group["eps"]
+        config["lasso"] = group["lasso"]
         config["weight_decay"] = group["weight_decay"]
         config["lr"] = group["lr"]
         config["optim_bits"] = self.args.optim_bits
@@ -345,6 +346,7 @@ class Optimizer2State(Optimizer8bit):
         lr=1e-3,
         betas=(0.9, 0.999),
         eps=1e-8,
+        lasso=0.0,
         weight_decay=0.0,
         optim_bits=32,
         args=None,
@@ -369,6 +371,8 @@ class Optimizer2State(Optimizer8bit):
                 The beta values for the optimizer.
             eps (`float`, defaults to 1e-8):
                 The epsilon value for the optimizer.
+            lasso (`float`, defaults to 0.0):
+                The lasso regularization coefficient value for the optimizer.
             weight_decay (`float`, defaults to 0.0):
                 The weight decay value for the optimizer.
             optim_bits (`int`, defaults to 32):
@@ -399,9 +403,11 @@ class Optimizer2State(Optimizer8bit):
         for i in range(len(betas)):
             if not 0.0 <= betas[i] < 1.0:
                 raise ValueError(f"Invalid beta parameter at index {i}: {betas[i]}")
+        if not 0.0 <= lasso:
+            raise ValueError(f"Invalid lasso regularization coefficient value: {lasso}")
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
-        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        defaults = dict(lr=lr, betas=betas, eps=eps, lasso=lasso, weight_decay=weight_decay)
         super().__init__(params, defaults, optim_bits, is_paged)
 
         if args is None:
@@ -508,6 +514,7 @@ class Optimizer2State(Optimizer8bit):
                 config["lr"],
                 state["state2"],
                 config["betas"][1],
+                config["lasso"],
                 config["weight_decay"],
                 gnorm_scale,
                 state["unorm_vec"] if config["max_unorm"] > 0.0 else None,
@@ -533,6 +540,7 @@ class Optimizer2State(Optimizer8bit):
                 state["max2"],
                 state["new_max1"],
                 state["new_max2"],
+                config["lasso"],
                 config["weight_decay"],
                 gnorm_scale=gnorm_scale,
                 unorm_vec=state["unorm_vec"] if config["max_unorm"] > 0.0 else None,
@@ -558,6 +566,7 @@ class Optimizer2State(Optimizer8bit):
                 state["qmap2"],
                 state["absmax1"],
                 state["absmax2"],
+                config["lasso"],
                 config["weight_decay"],
                 gnorm_scale=gnorm_scale,
                 skip_zeros=config["skip_zeros"],
@@ -572,6 +581,7 @@ class Optimizer1State(Optimizer8bit):
         lr=1e-3,
         betas=(0.9, 0.0),
         eps=1e-8,
+        lasso=0.0,
         weight_decay=0.0,
         optim_bits=32,
         args=None,
@@ -596,6 +606,8 @@ class Optimizer1State(Optimizer8bit):
                 The beta values for the optimizer.
             eps (`float`, defaults to 1e-8):
                 The epsilon value for the optimizer.
+            lasso (`float`, defaults to 0.0):
+                The lasso regularization coefficient value for the optimizer.
             weight_decay (`float`, defaults to 0.0):
                 The weight decay value for the optimizer.
             optim_bits (`int`, defaults to 32):
@@ -622,9 +634,11 @@ class Optimizer1State(Optimizer8bit):
         for i in range(len(betas)):
             if not 0.0 <= betas[i] < 1.0:
                 raise ValueError(f"Invalid beta parameter at index {i}: {betas[i]}")
+        if not 0.0 <= lasso:
+            raise ValueError(f"Invalid lasso regularization coefficient value: {lasso}")
         if not 0.0 <= weight_decay:
             raise ValueError(f"Invalid weight_decay value: {weight_decay}")
-        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        defaults = dict(lr=lr, betas=betas, eps=eps, lasso=lasso, weight_decay=weight_decay)
         super().__init__(params, defaults, optim_bits, is_paged)
 
         if args is None:
@@ -723,6 +737,7 @@ class Optimizer1State(Optimizer8bit):
                 config["lr"],
                 None,
                 config["betas"][1],
+                config["lasso"],
                 config["weight_decay"],
                 gnorm_scale,
                 state["unorm_vec"] if config["max_unorm"] > 0.0 else None,
@@ -748,6 +763,7 @@ class Optimizer1State(Optimizer8bit):
                 None,
                 state["new_max1"],
                 None,
+                config["lasso"],
                 config["weight_decay"],
                 gnorm_scale,
                 state["unorm_vec"] if config["max_unorm"] > 0.0 else None,
@@ -771,6 +787,7 @@ class Optimizer1State(Optimizer8bit):
                 None,
                 state["absmax1"],
                 None,
+                config["lasso"],
                 config["weight_decay"],
                 gnorm_scale=gnorm_scale,
                 skip_zeros=config["skip_zeros"],

--- a/csrc/kernels.cu
+++ b/csrc/kernels.cu
@@ -1067,9 +1067,9 @@ __global__ void kOptimizer32bit2State(T* g, T* p,
 
 
                     if(lasso > 0.0f && weight_decay > 0.0f)
-                        p_vals[j] = ((float)p_vals[j])*(1.0f-(lr*weight_decay)) - ((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*((float)(lr*lasso));
+                        p_vals[j] = ((float)p_vals[j])*(1.0f-(lr*weight_decay)) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
                     else if(lasso > 0.0f)
-                        p_vals[j] = ((float)p_vals[j]) - ((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*((float)(lr*lasso));
+                        p_vals[j] = ((float)p_vals[j]) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
                     else if(weight_decay > 0.0f)
                         p_vals[j] = ((float)p_vals[j])*(1.0f-(lr*weight_decay));
 									}
@@ -1222,9 +1222,9 @@ __global__ void kOptimizer32bit1State(T *g, T *p,
       {
         g_vals[j] = gnorm_scale*((float)g_vals[j]);
         if(lasso > 0.0f && weight_decay > 0.0f)
-            p_vals[j] = (float)g_vals[j] + (((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*lasso) + (((float)p_vals[j])*weight_decay);
+            p_vals[j] = (float)g_vals[j] + (((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*lasso) + (((float)p_vals[j])*weight_decay);
         else if(lasso > 0.0f)
-            g_vals[j] = (float)g_vals[j] + (((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*lasso);
+            g_vals[j] = (float)g_vals[j] + (((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*lasso);
         else if(weight_decay > 0.0f)
             g_vals[j] = (float)g_vals[j] + (((float)p_vals[j])*weight_decay);
       }
@@ -1498,9 +1498,9 @@ kOptimizerStatic8bit2State(T* p, T* const g, unsigned char* state1, unsigned cha
         {
             p_vals[j] = (T)(((float)p_vals[j]) + ((update_scale*step_size*(s1_vals[j]/(sqrtf(s2_vals[j])+(correction2*eps))))));
             if(lasso > 0.0f && weight_decay > 0.0f)
-                p_vals[j] = update_scale*(((float)p_vals[j])*(1.0f-(lr*weight_decay)) - ((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*((float)(lr*lasso)));
+                p_vals[j] = update_scale*(((float)p_vals[j])*(1.0f-(lr*weight_decay)) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso)));
             else if(lasso > 0.0f)
-                p_vals[j] = update_scale*(((float)p_vals[j]) - ((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*((float)(lr*lasso)));
+                p_vals[j] = update_scale*(((float)p_vals[j]) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso)));
             else if(weight_decay > 0.0f)
                 p_vals[j] = update_scale*((float)p_vals[j])*(1.0f-(lr*weight_decay));
         }
@@ -1678,20 +1678,20 @@ kOptimizerStatic8bit1State(T* p, T* const g, unsigned char* state1,
                 switch(OPTIMIZER) {
                 case MOMENTUM:
                 case RMSPROP:
-                  g_val += ((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*lasso + ((float)p_vals[j])*weight_decay;
+                  g_val += ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*lasso + ((float)p_vals[j])*weight_decay;
                   break;
                 case LION:
-                  p_vals[j] = ((float)p_vals[j])*(1.0f-lr*weight_decay) - ((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*((float)(lr*lasso));
+                  p_vals[j] = ((float)p_vals[j])*(1.0f-lr*weight_decay) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
                   break;
               }
             else if(lasso > 0.0f)
                 switch(OPTIMIZER) {
                 case MOMENTUM:
                 case RMSPROP:
-                  g_val += ((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*lasso;
+                  g_val += ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*lasso;
                   break;
                 case LION:
-                  p_vals[j] = ((float)p_vals[j]) - ((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*((float)(lr*lasso));
+                  p_vals[j] = ((float)p_vals[j]) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
                   break;
               }
             else if(weight_decay > 0.0f) {
@@ -1947,9 +1947,9 @@ kOptimizerStatic8bit2StateBlockwise(T* p, T* __restrict__ const g, unsigned char
 						{
 							p_vals[j] = (T)(((float)p_vals[j]) + ((step_size*(__fdividef(s1_vals[j],(sqrtf(s2_vals[j])+(correction2*eps)))))));
 							if(lasso > 0.0f && weight_decay > 0.0f)
-                                p_vals[j] = ((float)p_vals[j])*(1.0f-(lr*weight_decay)) - ((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*((float)(lr*lasso));
+                                p_vals[j] = ((float)p_vals[j])*(1.0f-(lr*weight_decay)) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
                             else if(lasso > 0.0f)
-                                p_vals[j] = ((float)p_vals[j]) - ((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*((float)(lr*lasso));
+                                p_vals[j] = ((float)p_vals[j]) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
                             else if(weight_decay > 0.0f)
                                 p_vals[j] = ((float)p_vals[j])*(1.0f-(lr*weight_decay));
 						}
@@ -2070,20 +2070,20 @@ kOptimizerStatic8bit1StateBlockwise(T* p, T* __restrict__ const g, unsigned char
                 switch(OPTIMIZER) {
                 case MOMENTUM:
                 case RMSPROP:
-                  g_val += ((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*lasso + ((float)p_vals[j])*weight_decay;
+                  g_val += ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*lasso + ((float)p_vals[j])*weight_decay;
                   break;
                 case LION:
-                  p_vals[j] = ((float)p_vals[j])*(1.0f-lr*weight_decay) - ((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*((float)(lr*lasso));
+                  p_vals[j] = ((float)p_vals[j])*(1.0f-lr*weight_decay) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
                   break;
               }
             else if(lasso > 0.0f)
                 switch(OPTIMIZER) {
                 case MOMENTUM:
                 case RMSPROP:
-                  g_val += ((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*lasso;
+                  g_val += ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*lasso;
                   break;
                 case LION:
-                  p_vals[j] = ((float)p_vals[j]) - ((float)((p_vals[j] > 0) - (p_vals[j] < 0)))*((float)(lr*lasso));
+                  p_vals[j] = ((float)p_vals[j]) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
                   break;
               }
             else if(weight_decay > 0.0f) {

--- a/csrc/kernels.cu
+++ b/csrc/kernels.cu
@@ -1067,9 +1067,9 @@ __global__ void kOptimizer32bit2State(T* g, T* p,
 
 
                     if(lasso > 0.0f && weight_decay > 0.0f)
-                        p_vals[j] = ((float)p_vals[j])*(1.0f-(lr*weight_decay)) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
+                        p_vals[j] = ((float)p_vals[j])*(1.0f-(lr*weight_decay)) - ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*((float)(lr*lasso));
                     else if(lasso > 0.0f)
-                        p_vals[j] = ((float)p_vals[j]) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
+                        p_vals[j] = ((float)p_vals[j]) - ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*((float)(lr*lasso));
                     else if(weight_decay > 0.0f)
                         p_vals[j] = ((float)p_vals[j])*(1.0f-(lr*weight_decay));
 									}
@@ -1222,9 +1222,9 @@ __global__ void kOptimizer32bit1State(T *g, T *p,
       {
         g_vals[j] = gnorm_scale*((float)g_vals[j]);
         if(lasso > 0.0f && weight_decay > 0.0f)
-            p_vals[j] = (float)g_vals[j] + (((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*lasso) + (((float)p_vals[j])*weight_decay);
+            p_vals[j] = (float)g_vals[j] + (((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*lasso) + (((float)p_vals[j])*weight_decay);
         else if(lasso > 0.0f)
-            g_vals[j] = (float)g_vals[j] + (((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*lasso);
+            g_vals[j] = (float)g_vals[j] + (((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*lasso);
         else if(weight_decay > 0.0f)
             g_vals[j] = (float)g_vals[j] + (((float)p_vals[j])*weight_decay);
       }
@@ -1498,9 +1498,9 @@ kOptimizerStatic8bit2State(T* p, T* const g, unsigned char* state1, unsigned cha
         {
             p_vals[j] = (T)(((float)p_vals[j]) + ((update_scale*step_size*(s1_vals[j]/(sqrtf(s2_vals[j])+(correction2*eps))))));
             if(lasso > 0.0f && weight_decay > 0.0f)
-                p_vals[j] = update_scale*(((float)p_vals[j])*(1.0f-(lr*weight_decay)) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso)));
+                p_vals[j] = update_scale*(((float)p_vals[j])*(1.0f-(lr*weight_decay)) - ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*((float)(lr*lasso)));
             else if(lasso > 0.0f)
-                p_vals[j] = update_scale*(((float)p_vals[j]) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso)));
+                p_vals[j] = update_scale*(((float)p_vals[j]) - ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*((float)(lr*lasso)));
             else if(weight_decay > 0.0f)
                 p_vals[j] = update_scale*((float)p_vals[j])*(1.0f-(lr*weight_decay));
         }
@@ -1678,20 +1678,20 @@ kOptimizerStatic8bit1State(T* p, T* const g, unsigned char* state1,
                 switch(OPTIMIZER) {
                 case MOMENTUM:
                 case RMSPROP:
-                  g_val += ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*lasso + ((float)p_vals[j])*weight_decay;
+                  g_val += ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*lasso + ((float)p_vals[j])*weight_decay;
                   break;
                 case LION:
-                  p_vals[j] = ((float)p_vals[j])*(1.0f-lr*weight_decay) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
+                  p_vals[j] = ((float)p_vals[j])*(1.0f-lr*weight_decay) - ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*((float)(lr*lasso));
                   break;
               }
             else if(lasso > 0.0f)
                 switch(OPTIMIZER) {
                 case MOMENTUM:
                 case RMSPROP:
-                  g_val += ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*lasso;
+                  g_val += ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*lasso;
                   break;
                 case LION:
-                  p_vals[j] = ((float)p_vals[j]) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
+                  p_vals[j] = ((float)p_vals[j]) - ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*((float)(lr*lasso));
                   break;
               }
             else if(weight_decay > 0.0f) {
@@ -1947,9 +1947,9 @@ kOptimizerStatic8bit2StateBlockwise(T* p, T* __restrict__ const g, unsigned char
 						{
 							p_vals[j] = (T)(((float)p_vals[j]) + ((step_size*(__fdividef(s1_vals[j],(sqrtf(s2_vals[j])+(correction2*eps)))))));
 							if(lasso > 0.0f && weight_decay > 0.0f)
-                                p_vals[j] = ((float)p_vals[j])*(1.0f-(lr*weight_decay)) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
+                                p_vals[j] = ((float)p_vals[j])*(1.0f-(lr*weight_decay)) - ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*((float)(lr*lasso));
                             else if(lasso > 0.0f)
-                                p_vals[j] = ((float)p_vals[j]) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
+                                p_vals[j] = ((float)p_vals[j]) - ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*((float)(lr*lasso));
                             else if(weight_decay > 0.0f)
                                 p_vals[j] = ((float)p_vals[j])*(1.0f-(lr*weight_decay));
 						}
@@ -2070,20 +2070,20 @@ kOptimizerStatic8bit1StateBlockwise(T* p, T* __restrict__ const g, unsigned char
                 switch(OPTIMIZER) {
                 case MOMENTUM:
                 case RMSPROP:
-                  g_val += ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*lasso + ((float)p_vals[j])*weight_decay;
+                  g_val += ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*lasso + ((float)p_vals[j])*weight_decay;
                   break;
                 case LION:
-                  p_vals[j] = ((float)p_vals[j])*(1.0f-lr*weight_decay) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
+                  p_vals[j] = ((float)p_vals[j])*(1.0f-lr*weight_decay) - ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*((float)(lr*lasso));
                   break;
               }
             else if(lasso > 0.0f)
                 switch(OPTIMIZER) {
                 case MOMENTUM:
                 case RMSPROP:
-                  g_val += ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*lasso;
+                  g_val += ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*lasso;
                   break;
                 case LION:
-                  p_vals[j] = ((float)p_vals[j]) - ((float)(((float)p_vals[j] > 0) - ((float)p_vals[j] < 0)))*((float)(lr*lasso));
+                  p_vals[j] = ((float)p_vals[j]) - ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*((float)(lr*lasso));
                   break;
               }
             else if(weight_decay > 0.0f) {

--- a/csrc/kernels.cu
+++ b/csrc/kernels.cu
@@ -1674,36 +1674,33 @@ kOptimizerStatic8bit1State(T* p, T* const g, unsigned char* state1,
             g_val = float(g_vals[j]);
             g_val *= gnorm_scale;
 
-            if(lasso > 0.0f && weight_decay > 0.0f)
-                switch(OPTIMIZER) {
-                case MOMENTUM:
-                case RMSPROP:
-                  g_val += ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*lasso + ((float)p_vals[j])*weight_decay;
-                  break;
-                case LION:
-                  p_vals[j] = ((float)p_vals[j])*(1.0f-lr*weight_decay) - ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*((float)(lr*lasso));
-                  break;
-              }
-            else if(lasso > 0.0f)
-                switch(OPTIMIZER) {
-                case MOMENTUM:
-                case RMSPROP:
-                  g_val += ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*lasso;
-                  break;
-                case LION:
-                  p_vals[j] = ((float)p_vals[j]) - ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*((float)(lr*lasso));
-                  break;
-              }
-            else if(weight_decay > 0.0f) {
-              switch(OPTIMIZER) {
-                case MOMENTUM:
-                case RMSPROP:
-                  g_val += ((float)p_vals[j])*weight_decay;
-                  break;
-                case LION:
-                  p_vals[j] = ((float)p_vals[j])*(1.0f-lr*weight_decay);
-                  break;
-              }
+            if(lasso > 0.0f || weight_decay > 0.0f)
+            {
+                switch (OPTIMIZER)
+                {
+                    case MOMENTUM:
+                    case ADAGRAD:
+                    case RMSPROP:
+                    {
+                        if (lasso > 0.0f && weight_decay > 0.0f)
+                            g_val += ((float) (((float) p_vals[j] > ((float) (lr * lasso))) - ((float) p_vals[j] < -((float) (lr * lasso))))) * lasso + ((float) p_vals[j]) * weight_decay;
+                        else if (lasso > 0.0f)
+                            g_val += ((float) (((float) p_vals[j] > ((float) (lr * lasso))) - ((float) p_vals[j] < -((float) (lr * lasso))))) * lasso;
+                        else if (weight_decay > 0.0f)
+                            g_val += ((float) p_vals[j]) * weight_decay;
+                        break;
+                    }
+                    case LION:
+                    {
+                        if (lasso > 0.0f && weight_decay > 0.0f)
+                            p_vals[j] = ((float) p_vals[j]) * (1.0f - lr * weight_decay) - ((float) (((float) p_vals[j] > ((float) (lr * lasso))) - ((float) p_vals[j] < -((float) (lr * lasso))))) * ((float) (lr * lasso));
+                        else if (lasso > 0.0f)
+                            p_vals[j] = ((float) p_vals[j]) - ((float) (((float) p_vals[j] > ((float) (lr * lasso))) - ((float) p_vals[j] < -((float) (lr * lasso))))) * ((float) (lr * lasso));
+                        else if (weight_decay > 0.0f)
+                            p_vals[j] = ((float) p_vals[j]) * (1.0f - lr * weight_decay);
+                        break;
+                    }
+                }
             }
 
             s1_vals[j] = smem_quantiles1[c1s[j]]*max1[0];
@@ -2066,37 +2063,34 @@ kOptimizerStatic8bit1StateBlockwise(T* p, T* __restrict__ const g, unsigned char
             g_val *= gnorm_scale;
             if(!skip_zeros || (skip_zeros && ((float)g_vals[j] != 0.0f)))
             {
-              if(lasso > 0.0f && weight_decay > 0.0f)
-                switch(OPTIMIZER) {
-                case MOMENTUM:
-                case RMSPROP:
-                  g_val += ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*lasso + ((float)p_vals[j])*weight_decay;
-                  break;
-                case LION:
-                  p_vals[j] = ((float)p_vals[j])*(1.0f-lr*weight_decay) - ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*((float)(lr*lasso));
-                  break;
-              }
-            else if(lasso > 0.0f)
-                switch(OPTIMIZER) {
-                case MOMENTUM:
-                case RMSPROP:
-                  g_val += ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*lasso;
-                  break;
-                case LION:
-                  p_vals[j] = ((float)p_vals[j]) - ((float)(((float)p_vals[j] > ((float)(lr*lasso))) - ((float)p_vals[j] < -((float)(lr*lasso)))))*((float)(lr*lasso));
-                  break;
-              }
-            else if(weight_decay > 0.0f) {
-              switch(OPTIMIZER) {
-                case MOMENTUM:
-                case RMSPROP:
-                  g_val += ((float)p_vals[j])*weight_decay;
-                  break;
-                case LION:
-                  p_vals[j] = ((float)p_vals[j])*(1.0f-lr*weight_decay);
-                  break;
-              }
-            }
+                if(lasso > 0.0f || weight_decay > 0.0f)
+                {
+                    switch (OPTIMIZER)
+                    {
+                        case MOMENTUM:
+                        case ADAGRAD:
+                        case RMSPROP:
+                        {
+                            if (lasso > 0.0f && weight_decay > 0.0f)
+                                g_val += ((float) (((float) p_vals[j] > ((float) (lr * lasso))) - ((float) p_vals[j] < -((float) (lr * lasso))))) * lasso + ((float) p_vals[j]) * weight_decay;
+                            else if (lasso > 0.0f)
+                                g_val += ((float) (((float) p_vals[j] > ((float) (lr * lasso))) - ((float) p_vals[j] < -((float) (lr * lasso))))) * lasso;
+                            else if (weight_decay > 0.0f)
+                                g_val += ((float) p_vals[j]) * weight_decay;
+                            break;
+                        }
+                        case LION:
+                        {
+                            if (lasso > 0.0f && weight_decay > 0.0f)
+                                p_vals[j] = ((float) p_vals[j]) * (1.0f - lr * weight_decay) - ((float) (((float) p_vals[j] > ((float) (lr * lasso))) - ((float) p_vals[j] < -((float) (lr * lasso))))) * ((float) (lr * lasso));
+                            else if (lasso > 0.0f)
+                                p_vals[j] = ((float) p_vals[j]) - ((float) (((float) p_vals[j] > ((float) (lr * lasso))) - ((float) p_vals[j] < -((float) (lr * lasso))))) * ((float) (lr * lasso));
+                            else if (weight_decay > 0.0f)
+                                p_vals[j] = ((float) p_vals[j]) * (1.0f - lr * weight_decay);
+                            break;
+                        }
+                    }
+                }
 
 							s1_vals[j] = smem_quantiles1[lane_id][c1s[j]]*absmax1[i/BLOCK_SIZE];
 

--- a/csrc/kernels.cuh
+++ b/csrc/kernels.cuh
@@ -23,25 +23,25 @@ template<typename T, int OPTIMIZER, int BLOCK_SIZE, int NUM_VALS>
 __global__ void kPreconditionOptimizer32bit2State(T* g, T* p,
                 float* state1, float* state2, float *unorm,
                 const float beta1, const float beta2, const float eps, const float lasso, const float weight_decay,
-                const int step, const float lr, const float gnorm_scale, const int n);
+                const int step, const float lr, const float lr_reg, const float gnorm_scale, const int n);
 
 template<typename T, int OPTIMIZER>
 __global__ void kOptimizer32bit2State(T* g, T* p,
                 float* state1, float* state2, float *unorm, const float max_unorm, const float param_norm,
                 const float beta1, const float beta2, const float eps, const float lasso, const float weight_decay,
-                const int step, const float lr, const float gnorm_scale, const bool skip_zeros, const int n);
+                const int step, const float lr, const float lr_reg, const float gnorm_scale, const bool skip_zeros, const int n);
 
 template<typename T, int OPTIMIZER, int BLOCK_SIZE, int NUM_VALS>
 __global__ void kPreconditionOptimizer32bit1State(T* g, T* p,
                 float* state1, float *unorm,
                 const float beta1, const float beta2, const float eps, const float lasso, const float weight_decay,
-                const int step, const float lr, const float gnorm_scale, const int n);
+                const int step, const float lr, const float lr_reg, const float gnorm_scale, const int n);
 
 template<typename T, int OPTIMIZER>
 __global__ void kOptimizer32bit1State(T* g, T* p,
                 float* state1,  float *unorm, const float max_unorm, const float param_norm,
                 const float beta1, const float beta2, const float eps, const float lasso, const float weight_decay,
-                const int step, const float lr, const float gnorm_scale, const bool skip_zeros, const int n);
+                const int step, const float lr, const float lr_reg, const float gnorm_scale, const bool skip_zeros, const int n);
 
 template<typename T, int OPTIMIZER>
 __global__ void
@@ -60,7 +60,7 @@ __global__ void
 kOptimizerStatic8bit1State(T* p, T* const g, unsigned char* state1,
                 const float *unorm, const float max_unorm, const float param_norm,
                 const float beta1, const float beta2,
-                const float eps, const int step, const float lr,
+                const float eps, const int step, const float lr, const float lr_reg,
                 float* __restrict__ const quantiles1,
                 float* max1, float* new_max1,
                 float lasso, float weight_decay, const float gnorm_scale, const int n);
@@ -83,21 +83,21 @@ __global__ void
 kOptimizerStatic8bit2State(T* p, T* const g, unsigned char* state1, unsigned char* state2,
                 const float *unorm, const float max_unorm, const float param_norm,
                 const float beta1, const float beta2,
-                const float eps, const int step, const float lr,
+                const float eps, const int step, const float lr, const float lr_reg,
                 float* __restrict__ const quantiles1, float* __restrict__ const quantiles2,
                 float* max1, float* max2, float* new_max1, float* new_max2,
                 float lasso, float weight_decay, const float gnorm_scale, const int n);
 
 template<typename T, int OPTIMIZER, int BLOCK_SIZE, int N_PER_TH> __global__ void kOptimizerStatic8bit2StateBlockwise(
 		T* p, T* __restrict__ const g, unsigned char* state1, unsigned char* state2,
-                const float beta1, const float beta2, const float eps, const int step, const float lr,
+                const float beta1, const float beta2, const float eps, const int step, const float lr, const float lr_reg,
                 float* __restrict__ const quantiles1, float* __restrict__ const quantiles2,
                 float* absmax1, float* absmax2, float lasso, float weight_decay, const float gnorm_scale, const bool skip_zeros, const int n);
 
 template<typename T, int OPTIMIZER, int BLOCK_SIZE, int N_PER_TH> __global__ void kOptimizerStatic8bit1StateBlockwise(
 		T* p, T* __restrict__ const g, unsigned char* state1,
                 const float beta1, const float beta2,
-                const float eps, const int step, const float lr,
+                const float eps, const int step, const float lr, const float lr_reg,
                 float* __restrict__ const quantiles1,
                 float* absmax1,
                 float lasso, float weight_decay,

--- a/csrc/kernels.cuh
+++ b/csrc/kernels.cuh
@@ -22,25 +22,25 @@ template<typename T, int BLOCK_SIZE, int THREADS, int NUM_PER_TH, int DATA_TYPE>
 template<typename T, int OPTIMIZER, int BLOCK_SIZE, int NUM_VALS>
 __global__ void kPreconditionOptimizer32bit2State(T* g, T* p,
                 float* state1, float* state2, float *unorm,
-                const float beta1, const float beta2, const float eps, const float weight_decay,
+                const float beta1, const float beta2, const float eps, const float lasso, const float weight_decay,
                 const int step, const float lr, const float gnorm_scale, const int n);
 
 template<typename T, int OPTIMIZER>
 __global__ void kOptimizer32bit2State(T* g, T* p,
                 float* state1, float* state2, float *unorm, const float max_unorm, const float param_norm,
-                const float beta1, const float beta2, const float eps, const float weight_decay,
+                const float beta1, const float beta2, const float eps, const float lasso, const float weight_decay,
                 const int step, const float lr, const float gnorm_scale, const bool skip_zeros, const int n);
 
 template<typename T, int OPTIMIZER, int BLOCK_SIZE, int NUM_VALS>
 __global__ void kPreconditionOptimizer32bit1State(T* g, T* p,
                 float* state1, float *unorm,
-                const float beta1, const float beta2, const float eps, const float weight_decay,
+                const float beta1, const float beta2, const float eps, const float lasso, const float weight_decay,
                 const int step, const float lr, const float gnorm_scale, const int n);
 
 template<typename T, int OPTIMIZER>
 __global__ void kOptimizer32bit1State(T* g, T* p,
                 float* state1,  float *unorm, const float max_unorm, const float param_norm,
-                const float beta1, const float beta2, const float eps, const float weight_decay,
+                const float beta1, const float beta2, const float eps, const float lasso, const float weight_decay,
                 const int step, const float lr, const float gnorm_scale, const bool skip_zeros, const int n);
 
 template<typename T, int OPTIMIZER>
@@ -51,7 +51,7 @@ kPreconditionOptimizerStatic8bit1State(T* p, T* __restrict__ const g, unsigned c
                 const float eps, const int step,
                 float* __restrict__ const quantiles1,
                 float* max1, float* new_max1,
-                const float weight_decay,
+                const float lasso, const float weight_decay,
                 const float gnorm_scale, const int n);
 
 
@@ -63,7 +63,7 @@ kOptimizerStatic8bit1State(T* p, T* const g, unsigned char* state1,
                 const float eps, const int step, const float lr,
                 float* __restrict__ const quantiles1,
                 float* max1, float* new_max1,
-                float weight_decay, const float gnorm_scale, const int n);
+                float lasso, float weight_decay, const float gnorm_scale, const int n);
 
 
 
@@ -86,13 +86,13 @@ kOptimizerStatic8bit2State(T* p, T* const g, unsigned char* state1, unsigned cha
                 const float eps, const int step, const float lr,
                 float* __restrict__ const quantiles1, float* __restrict__ const quantiles2,
                 float* max1, float* max2, float* new_max1, float* new_max2,
-                float weight_decay, const float gnorm_scale, const int n);
+                float lasso, float weight_decay, const float gnorm_scale, const int n);
 
 template<typename T, int OPTIMIZER, int BLOCK_SIZE, int N_PER_TH> __global__ void kOptimizerStatic8bit2StateBlockwise(
 		T* p, T* __restrict__ const g, unsigned char* state1, unsigned char* state2,
                 const float beta1, const float beta2, const float eps, const int step, const float lr,
                 float* __restrict__ const quantiles1, float* __restrict__ const quantiles2,
-                float* absmax1, float* absmax2, float weight_decay, const float gnorm_scale, const bool skip_zeros, const int n);
+                float* absmax1, float* absmax2, float lasso, float weight_decay, const float gnorm_scale, const bool skip_zeros, const int n);
 
 template<typename T, int OPTIMIZER, int BLOCK_SIZE, int N_PER_TH> __global__ void kOptimizerStatic8bit1StateBlockwise(
 		T* p, T* __restrict__ const g, unsigned char* state1,
@@ -100,7 +100,7 @@ template<typename T, int OPTIMIZER, int BLOCK_SIZE, int N_PER_TH> __global__ voi
                 const float eps, const int step, const float lr,
                 float* __restrict__ const quantiles1,
                 float* absmax1,
-                float weight_decay,
+                float lasso, float weight_decay,
                 const float gnorm_scale, const bool skip_zeros, const int n);
 
 

--- a/csrc/ops.cu
+++ b/csrc/ops.cu
@@ -101,7 +101,7 @@ template<typename T, int DATA_TYPE> void dequantizeBlockwise(float *code, unsign
 
 template<typename T, int OPTIMIZER> void optimizer32bit(T* g, T* p,
                 float* state1, float* state2, float *unorm, float max_unorm, float param_norm,
-                const float beta1, const float beta2, const float eps, const float weight_decay,
+                const float beta1, const float beta2, const float eps, const float lasso, const float weight_decay,
                 const int step, const float lr, const float gnorm_scale, bool skip_zeros, const int n)
 {
   int num_blocks = n/4096;
@@ -112,10 +112,10 @@ template<typename T, int OPTIMIZER> void optimizer32bit(T* g, T* p,
       if(max_unorm > 0.0f)
 			{
 				CUDA_CHECK_RETURN(cudaMemset(unorm, 0, 1*sizeof(float)));
-        kPreconditionOptimizer32bit2State<T, OPTIMIZER, 4096, 8><<<num_blocks, 512>>>(g, p, state1, state2, unorm, beta1, beta2, eps, weight_decay, step, lr, gnorm_scale, n);
+        kPreconditionOptimizer32bit2State<T, OPTIMIZER, 4096, 8><<<num_blocks, 512>>>(g, p, state1, state2, unorm, beta1, beta2, eps, lasso, weight_decay, step, lr, gnorm_scale, n);
         CUDA_CHECK_RETURN(cudaPeekAtLastError());
       }
-			kOptimizer32bit2State<T, OPTIMIZER><<<num_blocks, 1024>>>(g, p, state1, state2, unorm, max_unorm, param_norm, beta1, beta2, eps, weight_decay, step, lr, gnorm_scale, skip_zeros, n);
+			kOptimizer32bit2State<T, OPTIMIZER><<<num_blocks, 1024>>>(g, p, state1, state2, unorm, max_unorm, param_norm, beta1, beta2, eps, lasso, weight_decay, step, lr, gnorm_scale, skip_zeros, n);
       CUDA_CHECK_RETURN(cudaPeekAtLastError());
 			break;
 		case MOMENTUM:
@@ -124,22 +124,22 @@ template<typename T, int OPTIMIZER> void optimizer32bit(T* g, T* p,
       if(max_unorm > 0.0f)
 			{
 				CUDA_CHECK_RETURN(cudaMemset(unorm, 0, 1*sizeof(float)));
-				kPreconditionOptimizer32bit1State<T, OPTIMIZER, 4096, 8><<<num_blocks, 512>>>(g, p, state1, unorm, beta1, beta2, eps, weight_decay, step, lr, gnorm_scale, n);
+				kPreconditionOptimizer32bit1State<T, OPTIMIZER, 4096, 8><<<num_blocks, 512>>>(g, p, state1, unorm, beta1, beta2, eps, lasso, weight_decay, step, lr, gnorm_scale, n);
         CUDA_CHECK_RETURN(cudaPeekAtLastError());
 			}
 
-			kOptimizer32bit1State<T, OPTIMIZER><<<num_blocks, 1024>>>(g, p, state1, unorm, max_unorm, param_norm, beta1, beta2, eps, weight_decay, step, lr, gnorm_scale, skip_zeros, n);
+			kOptimizer32bit1State<T, OPTIMIZER><<<num_blocks, 1024>>>(g, p, state1, unorm, max_unorm, param_norm, beta1, beta2, eps, lasso, weight_decay, step, lr, gnorm_scale, skip_zeros, n);
       CUDA_CHECK_RETURN(cudaPeekAtLastError());
 			break;
     case LION:
       // in lion, the momentum update after the parameter update
-      kOptimizer32bit1State<T, OPTIMIZER><<<num_blocks, 1024>>>(g, p, state1, unorm, max_unorm, param_norm, beta1, beta2, eps, weight_decay, step, lr, gnorm_scale, skip_zeros, n);
+      kOptimizer32bit1State<T, OPTIMIZER><<<num_blocks, 1024>>>(g, p, state1, unorm, max_unorm, param_norm, beta1, beta2, eps, lasso, weight_decay, step, lr, gnorm_scale, skip_zeros, n);
       CUDA_CHECK_RETURN(cudaPeekAtLastError());
 
       if(max_unorm > 0.0f)
       {
         CUDA_CHECK_RETURN(cudaMemset(unorm, 0, 1*sizeof(float)));
-        kPreconditionOptimizer32bit1State<T, OPTIMIZER, 4096, 8><<<num_blocks, 512>>>(g, p, state1, unorm, beta1, beta2, eps, weight_decay, step, lr, gnorm_scale, n);
+        kPreconditionOptimizer32bit1State<T, OPTIMIZER, 4096, 8><<<num_blocks, 512>>>(g, p, state1, unorm, beta1, beta2, eps, lasso, weight_decay, step, lr, gnorm_scale, n);
         CUDA_CHECK_RETURN(cudaPeekAtLastError());
       }
       break;
@@ -153,7 +153,7 @@ template<typename T, int OPTIMIZER> void optimizerStatic8bit(T* p, T* g,
                 float eps, int step, float lr,
                 float* quantiles1, float* quantiles2,
                 float* max1, float* max2, float* new_max1, float* new_max2,
-                float weight_decay,
+                float lasso, float weight_decay,
                 const float gnorm_scale, int n)
 {
   int num_blocks = n/4096;
@@ -169,27 +169,27 @@ template<typename T, int OPTIMIZER> void optimizerStatic8bit(T* p, T* g,
 			kPreconditionOptimizerStatic8bit2State<T, OPTIMIZER><<<num_blocks, 256>>>(p, g, state1, state2, unorm, beta1, beta2, eps, step, quantiles1, quantiles2, max1, max2, new_max1, new_max2, gnorm_scale, n);
 			CUDA_CHECK_RETURN(cudaPeekAtLastError());
 			kOptimizerStatic8bit2State<T, OPTIMIZER><<<num_blocks, 1024>>>(p, g, state1, state2, unorm, max_unorm, param_norm, beta1, beta2, eps, step, lr,
-																														quantiles1, quantiles2, max1, max2, new_max1, new_max2, weight_decay, gnorm_scale, n);
+																														quantiles1, quantiles2, max1, max2, new_max1, new_max2, lasso, weight_decay, gnorm_scale, n);
 			CUDA_CHECK_RETURN(cudaPeekAtLastError());
 		break;
 		case MOMENTUM:
     case RMSPROP:
     case ADAGRAD:
 			CUDA_CHECK_RETURN(cudaMemset(new_max1, 0, 1*sizeof(float)));
-			kPreconditionOptimizerStatic8bit1State<T, OPTIMIZER><<<num_blocks, 256>>>(p, g, state1, unorm, beta1, beta2, eps, step, quantiles1, max1, new_max1, weight_decay, gnorm_scale, n);
+			kPreconditionOptimizerStatic8bit1State<T, OPTIMIZER><<<num_blocks, 256>>>(p, g, state1, unorm, beta1, beta2, eps, step, quantiles1, max1, new_max1, lasso, weight_decay, gnorm_scale, n);
 			CUDA_CHECK_RETURN(cudaPeekAtLastError());
 			kOptimizerStatic8bit1State<T, OPTIMIZER><<<num_blocks, 1024>>>(p, g, state1, unorm, max_unorm, param_norm, beta1, beta2, eps, step, lr,
-																														quantiles1, max1, new_max1, weight_decay, gnorm_scale, n);
+																														quantiles1, max1, new_max1, lasso, weight_decay, gnorm_scale, n);
 			CUDA_CHECK_RETURN(cudaPeekAtLastError());
 			break;
     case LION:
       // in lion, the momentum update happens after the parameter update
       kOptimizerStatic8bit1State<T, OPTIMIZER><<<num_blocks, 1024>>>(p, g, state1, unorm, max_unorm, param_norm, beta1, beta2, eps, step, lr,
-                                                            quantiles1, max1, new_max1, weight_decay, gnorm_scale, n);
+                                                            quantiles1, max1, new_max1, lasso, weight_decay, gnorm_scale, n);
       CUDA_CHECK_RETURN(cudaPeekAtLastError());
 
       CUDA_CHECK_RETURN(cudaMemset(new_max1, 0, 1*sizeof(float)));
-      kPreconditionOptimizerStatic8bit1State<T, OPTIMIZER><<<num_blocks, 256>>>(p, g, state1, unorm, beta1, beta2, eps, step, quantiles1, max1, new_max1, weight_decay, gnorm_scale, n);
+      kPreconditionOptimizerStatic8bit1State<T, OPTIMIZER><<<num_blocks, 256>>>(p, g, state1, unorm, beta1, beta2, eps, step, quantiles1, max1, new_max1, lasso, weight_decay, gnorm_scale, n);
       CUDA_CHECK_RETURN(cudaPeekAtLastError());
       break;
 		default:
@@ -204,7 +204,7 @@ template<typename T, int OPTIMIZER> void optimizerStatic8bit(T* p, T* g,
 
 template<typename T, int OPTIMIZER> void optimizerStatic8bitBlockwise(T* p, T* g,
                 unsigned char* state1, unsigned char* state2, float beta1, float beta2, float eps, int step, float lr,
-                float* quantiles1, float* quantiles2, float* absmax1, float* absmax2, float weight_decay, const float gnorm_scale, bool skip_zeros, int n)
+                float* quantiles1, float* quantiles2, float* absmax1, float* absmax2, float lasso, float weight_decay, const float gnorm_scale, bool skip_zeros, int n)
 {
 
 	int num_blocks = 0;
@@ -214,7 +214,7 @@ template<typename T, int OPTIMIZER> void optimizerStatic8bitBlockwise(T* p, T* g
 			num_blocks = n/BLOCKSIZE_2STATE;
 			num_blocks = n % BLOCKSIZE_2STATE == 0 ? num_blocks : num_blocks + 1;
 			kOptimizerStatic8bit2StateBlockwise<T, OPTIMIZER, BLOCKSIZE_2STATE, NUM_2STATE><<<num_blocks, BLOCKSIZE_2STATE/NUM_2STATE>>>(p, g, state1, state2, beta1, beta2, eps, step, lr,
-																														quantiles1, quantiles2, absmax1, absmax2, weight_decay, gnorm_scale, skip_zeros, n);
+																														quantiles1, quantiles2, absmax1, absmax2, lasso, weight_decay, gnorm_scale, skip_zeros, n);
 			CUDA_CHECK_RETURN(cudaPeekAtLastError());
 		break;
 		case MOMENTUM:
@@ -224,7 +224,7 @@ template<typename T, int OPTIMIZER> void optimizerStatic8bitBlockwise(T* p, T* g
 			num_blocks = n/BLOCKSIZE_1STATE;
 			num_blocks = n % BLOCKSIZE_1STATE == 0 ? num_blocks : num_blocks + 1;
 			kOptimizerStatic8bit1StateBlockwise<T, OPTIMIZER, BLOCKSIZE_1STATE, NUM_1STATE><<<num_blocks, BLOCKSIZE_1STATE/NUM_1STATE>>>(p, g, state1, beta1, beta2, eps, step, lr,
-																														quantiles1, absmax1, weight_decay, gnorm_scale, skip_zeros, n);
+																														quantiles1, absmax1, lasso, weight_decay, gnorm_scale, skip_zeros, n);
 			CUDA_CHECK_RETURN(cudaPeekAtLastError());
 		break;
 	}
@@ -808,7 +808,7 @@ template void dequantizeBlockwise<__nv_bfloat16, NF4>(float *code, unsigned char
 #define MAKE_optimizer32bit(name, gtype) \
 template void optimizer32bit<gtype, name>(gtype* g, gtype* p, \
                 float* state1, float* state2, float* unorm, float max_unorm, float param_norm, \
-                const float beta1, const float beta2, const float eps, const float weight_decay, \
+                const float beta1, const float beta2, const float eps, const float lasso, const float weight_decay, \
                 const int step, const float lr, const float gnorm_scale, const bool skip_zeros, const int n);
 
 MAKE_optimizer32bit(ADAM, half)
@@ -831,7 +831,7 @@ template void optimizerStatic8bit<gtype, name>(gtype* p, gtype* g, unsigned char
                 float eps, int step, float lr,  \
                 float* quantiles1, float* quantiles2, \
                 float* max1, float* max2, float* new_max1, float* new_max2, \
-                float weight_decay, \
+                float lasso, float weight_decay, \
                 const float gnorm_scale, int n); \
 
 MAKE_optimizerStatic8bit(ADAM, half)
@@ -846,7 +846,7 @@ MAKE_optimizerStatic8bit(LION, float)
 #define MAKE_optimizerStatic8bitBlockwise(gtype, optim_name) \
 template void optimizerStatic8bitBlockwise<gtype, optim_name>(gtype* p, gtype* g, \
                 unsigned char* state1, unsigned char* state2, float beta1, float beta2, float eps, int step, float lr,  \
-                float* quantiles1, float* quantiles2, float* absmax1, float* absmax2, float weight_decay, const float gnorm_scale, bool skip_zeros, int n); \
+                float* quantiles1, float* quantiles2, float* absmax1, float* absmax2, float lasso, float weight_decay, const float gnorm_scale, bool skip_zeros, int n); \
 
 MAKE_optimizerStatic8bitBlockwise(half, ADAM);
 MAKE_optimizerStatic8bitBlockwise(float, ADAM);

--- a/csrc/ops.cuh
+++ b/csrc/ops.cuh
@@ -148,7 +148,7 @@ template<typename T, int DATA_TYPE> void dequantizeBlockwise(float *code, unsign
 
 template<typename T, int OPTIMIZER> void optimizer32bit(T* g, T* p,
                 float* state1, float* state2, float *unorm, float max_unorm, float param_norm,
-                float beta1, float beta2, float eps, float weight_decay,
+                float beta1, float beta2, float eps, float lasso, float weight_decay,
                 int step, float lr, const float gnorm_scale, bool skip_zeros, int n);
 
 template<typename T, int OPTIMIZER> void optimizerStatic8bit(T* p, T* g, unsigned char* state1, unsigned char* state2,
@@ -157,12 +157,12 @@ template<typename T, int OPTIMIZER> void optimizerStatic8bit(T* p, T* g, unsigne
                 float eps, int step, float lr,
                 float* quantiles1, float* quantiles2,
                 float* max1, float* max2, float* new_max1, float* new_max2,
-                float weight_decay,
+                float lasso, float weight_decay,
                 const float gnorm_scale, int n);
 
 template<typename T, int OPTIMIZER> void optimizerStatic8bitBlockwise(T* p, T* g,
                 unsigned char* state1, unsigned char* state2, float beta1, float beta2, float eps, int step, float lr,
-                float* quantiles1, float* quantiles2, float* absmax1, float* absmax2, float weight_decay, const float gnorm_scale,
+                float* quantiles1, float* quantiles2, float* absmax1, float* absmax2, float lasso, float weight_decay, const float gnorm_scale,
 								bool skip_zeros, int n);
 
 template<typename T> void percentileClipping(T * g, float *gnorm_vec, int step, const int n);

--- a/csrc/ops.cuh
+++ b/csrc/ops.cuh
@@ -149,19 +149,19 @@ template<typename T, int DATA_TYPE> void dequantizeBlockwise(float *code, unsign
 template<typename T, int OPTIMIZER> void optimizer32bit(T* g, T* p,
                 float* state1, float* state2, float *unorm, float max_unorm, float param_norm,
                 float beta1, float beta2, float eps, float lasso, float weight_decay,
-                int step, float lr, const float gnorm_scale, bool skip_zeros, int n);
+                int step, float lr, float lr_reg, const float gnorm_scale, bool skip_zeros, int n);
 
 template<typename T, int OPTIMIZER> void optimizerStatic8bit(T* p, T* g, unsigned char* state1, unsigned char* state2,
                 float *unorm, float max_unorm, float param_norm,
                 float beta1, float beta2,
-                float eps, int step, float lr,
+                float eps, int step, float lr, float lr_reg,
                 float* quantiles1, float* quantiles2,
                 float* max1, float* max2, float* new_max1, float* new_max2,
                 float lasso, float weight_decay,
                 const float gnorm_scale, int n);
 
 template<typename T, int OPTIMIZER> void optimizerStatic8bitBlockwise(T* p, T* g,
-                unsigned char* state1, unsigned char* state2, float beta1, float beta2, float eps, int step, float lr,
+                unsigned char* state1, unsigned char* state2, float beta1, float beta2, float eps, int step, float lr, float lr_reg,
                 float* quantiles1, float* quantiles2, float* absmax1, float* absmax2, float lasso, float weight_decay, const float gnorm_scale,
 								bool skip_zeros, int n);
 

--- a/csrc/pythonInterface.cpp
+++ b/csrc/pythonInterface.cpp
@@ -53,8 +53,8 @@ MAKE_ELEMENTWISE_FUNC(_mul, fp32, float, _MUL)
 void fname##32bit_grad_##gbits(gtype *g, gtype *p, \
                float* state1, float* state2, float *unorm, float max_unorm, float param_norm, \
                const float beta1, const float beta2, const float eps, const float lasso, const float weight_decay, \
-               const int step, const float lr, float gnorm_scale, bool skip_zeros, const int n) \
-{ optimizer32bit<gtype, oname>(g, p, state1, state2, unorm, max_unorm, param_norm, beta1, beta2, eps, lasso, weight_decay, step, lr, gnorm_scale, skip_zeros, n); } \
+               const int step, const float lr, const float lr_reg, float gnorm_scale, bool skip_zeros, const int n) \
+{ optimizer32bit<gtype, oname>(g, p, state1, state2, unorm, max_unorm, param_norm, beta1, beta2, eps, lasso, weight_decay, step, lr, lr_reg, gnorm_scale, skip_zeros, n); } \
 
 MAKE_FUNC32(momentum, MOMENTUM, float, 32)
 MAKE_FUNC32(momentum, MOMENTUM, half, 16)
@@ -73,12 +73,12 @@ MAKE_FUNC32(adagrad, ADAGRAD, half, 16)
 void fname##_static_8bit_grad_##gbits(gtype* p, gtype* g, unsigned char* state1, unsigned char* state2, \
 								float *unorm, float max_unorm, float param_norm, \
                 float beta1, float beta2, \
-                float eps, int step, float lr,  \
+                float eps, int step, float lr, float lr_reg,  \
                 float* quantiles1, float* quantiles2, \
                 float* max1, float* max2, float* new_max1, float* new_max2, \
                 float lasso, float weight_decay, float gnorm_scale, int n) \
 {  \
-	optimizerStatic8bit<gtype, oname>(g, p, state1, state2, unorm, max_unorm, param_norm, beta1, beta2, eps, step, lr, \
+	optimizerStatic8bit<gtype, oname>(g, p, state1, state2, unorm, max_unorm, param_norm, beta1, beta2, eps, step, lr, lr_reg, \
 			                                  quantiles1, quantiles2, max1, max2, new_max1, new_max2, lasso, weight_decay, gnorm_scale, n); \
 } \
 
@@ -93,9 +93,9 @@ MAKE_FUNC8(lion, LION, half, 16)
 
 #define MAKE_BLOCKWISE8(fname, optim_name, gtype, gbits) \
 void fname##_8bit_blockwise_grad_##gbits(gtype* p, gtype* g, \
-                unsigned char* state1, unsigned char* state2, float beta1, float beta2, float eps, int step, float lr, \
+                unsigned char* state1, unsigned char* state2, float beta1, float beta2, float eps, int step, float lr, float lr_reg, \
                 float* quantiles1, float* quantiles2, float* absmax1, float* absmax2, float lasso, float weight_decay, const float gnorm_scale, bool skip_zeros, int n)\
-{	optimizerStatic8bitBlockwise<gtype, optim_name>(p, g, state1, state2, beta1, beta2, eps, step, lr, quantiles1, quantiles2, absmax1, absmax2, lasso, weight_decay, gnorm_scale, skip_zeros, n); }\
+{	optimizerStatic8bitBlockwise<gtype, optim_name>(p, g, state1, state2, beta1, beta2, eps, step, lr, lr_reg, quantiles1, quantiles2, absmax1, absmax2, lasso, weight_decay, gnorm_scale, skip_zeros, n); }\
 
 MAKE_BLOCKWISE8(adam, ADAM, half, fp16)
 MAKE_BLOCKWISE8(adam, ADAM, float, fp32)
@@ -225,8 +225,8 @@ extern "C"
 	void c##name##32bit_grad_##gbits(gtype *g, gtype *p, \
 								 float* state1, float* state2, float *unorm, float max_unorm, float param_norm, \
 								 const float beta1, const float beta2, const float eps, const float lasso, const float weight_decay, \
-								 const int step, const float lr, const float gnorm_scale, bool skip_zeros, const int n) \
-	{ name##32bit_grad_##gbits(g, p, state1, state2, unorm, max_unorm, param_norm, beta1, beta2, eps, lasso, weight_decay, step, lr, gnorm_scale, skip_zeros, n); } \
+								 const int step, const float lr, const float lr_reg, const float gnorm_scale, bool skip_zeros, const int n) \
+	{ name##32bit_grad_##gbits(g, p, state1, state2, unorm, max_unorm, param_norm, beta1, beta2, eps, lasso, weight_decay, step, lr, lr_reg, gnorm_scale, skip_zeros, n); } \
 
 	MAKE_CFUNC32(adam, float, fp32)
 	MAKE_CFUNC32(adam, half, fp16)
@@ -245,12 +245,12 @@ extern "C"
 	void c##name##_static_8bit_grad_##gbits(gtype* p, gtype* g, unsigned char* state1, unsigned char* state2, \
                 float *unorm, float max_unorm, float param_norm, \
                 float beta1, float beta2, \
-                float eps, int step, float lr,  \
+                float eps, int step, float lr, float lr_reg,  \
                 float* quantiles1, float* quantiles2, \
                 float* max1, float* max2, float* new_max1, float* new_max2, \
                 float lasso, float weight_decay, float gnorm_scale, int n) \
   {  \
-	    name##_static_8bit_grad_##gbits(g, p, state1, state2, unorm, max_unorm, param_norm, beta1, beta2, eps, step, lr, \
+	    name##_static_8bit_grad_##gbits(g, p, state1, state2, unorm, max_unorm, param_norm, beta1, beta2, eps, step, lr, lr_reg, \
 			                                 quantiles1, quantiles2, max1, max2, new_max1, new_max2, lasso, weight_decay, gnorm_scale, n); \
   } \
 
@@ -265,9 +265,9 @@ extern "C"
 
   #define MAKE_CBLOCKWISE8(fname, optim_name, gtype, gbits) \
   void c##fname##_8bit_blockwise_grad_##gbits(gtype* p, gtype* g, \
-                unsigned char* state1, unsigned char* state2, float beta1, float beta2, float eps, int step, float lr,  \
+                unsigned char* state1, unsigned char* state2, float beta1, float beta2, float eps, int step, float lr, float lr_reg,  \
                 float* quantiles1, float* quantiles2, float* absmax1, float* absmax2, float lasso, float weight_decay, const float gnorm_scale, bool skip_zeros, int n) \
-  {	fname##_8bit_blockwise_grad_##gbits(p, g, state1, state2, beta1, beta2, eps, step, lr, quantiles1, quantiles2, absmax1, absmax2, lasso, weight_decay, gnorm_scale, skip_zeros, n); } \
+  {	fname##_8bit_blockwise_grad_##gbits(p, g, state1, state2, beta1, beta2, eps, step, lr, lr_reg, quantiles1, quantiles2, absmax1, absmax2, lasso, weight_decay, gnorm_scale, skip_zeros, n); } \
 
 	MAKE_CBLOCKWISE8(adam, ADAM, half, fp16)
 	MAKE_CBLOCKWISE8(adam, ADAM, float, fp32)


### PR DESCRIPTION
## Summary

This pull request introduces a new variant of the Adam optimizer called **AdamE**, where the **E** stands for Elastic Net. 
AdamE incorporates both L1 (Lasso) and L2 (Weight Decay) decoupled regularization using independent parameters, allowing for flexible settings. 
This addition enhances the regularization capabilities of the optimizer, supporting various configurations for different parameter groups.

## Features and Changes

- **Decoupled L1 and L2 Regularization**: The AdamE optimizer allows for both L1 and L2 regularization as in Elastic Net through separate coefficients. The regularization is decoupled from the Adam weights update component (as happens in the AdamW optimizer with the L2 regularization).
  - **Independent regularization coefficients**: AdamE optimizer allows for independent adjustment of L1 and L2 regularization coefficients, providing greater control over the regularization of model parameters (setting the coefficient to 0 will ensure that only the other of the two regularizations will be used).
  - **Support for parameter groups**: Different parameter groups can now have specific L1 and L2 values, enabling targeted regularization strategies.
  - **Support for different formats**: AdamE comes in different flavours, including the *base* version, the *8bit* variant and the *paged* variant.
- **Compatibility with Existing Optimizers**: The underlying shared classes of the optimizers, weights updated function and the cuda components have been extended to include the lasso regularization, without modifying the interfaces of the pre-existing optimizers.


## Implementation Details

- Added new optimizer classes in `bitsandbytes/optim/adame.py`. Here is the list of new optimizers that are now part of the `bitsandbytes/optim` module:
  - `AdamE`
  - `AdamE8bit`
  - `AdamE32bit`
  - `PagedAdamE`
  - `PagedAdamE8bit`
  - `PagedAdamE32bit`
- Introduced new parameter `lasso` for L1 regularization (the parameter defaults to 0 to avoid changing the behaviour of pre-existing optimizers) among the defaults of the following classes of `bitsandbytes/optim/optimizer.py`:
  - `Optimizer8bit`
  - `Optimizer2State` (parameter is also in the class constructor)
  - `Optimizer1State` (parameter is also in the class constructor)
- Introduced new parameter `lasso` for L1 regularization (the parameter defaults to 0 to avoid changing the behaviour of pre-existing optimizers) among the parameters of the following optimizer update function in `bitsandbytes/functional.py`:
  - `optimizer_update_32bit`
  - `optimizer_update_8bit`
  - `optimizer_update_8bit_blockwise`
- Updated documentation to include all the versions of the new optimizer and to explain the new parameter in the low level optimizer classes and the update functions.
- Updated accordingly all CUDA kernels and interfaces inside `csrc`; in particular, the following files have been modified to introduce the new parameter `lasso` for L1 regularization:
  - `csrc/kernels.cu`
  - `csrc/kernels.cuh`
  - `csrc/ops.cu`
  - `csrc/ops.cuh`
  - `csrc/pythonInterface.cpp`

## Motivation

The addition of the AdamE optimizer provides a more robust and flexible approach to regularization, particularly in deep learning models with complex structures and varying regularization requirements. 
By allowing decoupled L1 and L2 regularization, this optimizer can help prevent overfitting and improve model generalization. 
In particular, this Adam variant introduces L1 regularization, which wasn't properly supported before.
Moreover, the fine-grained control coming from this implementation allows complete choice over the amount and modalities of regularization without impacting usability.

## Request for Feedback

I would appreciate any feedback on the implementation and documentation of the AdamE optimizer. 
Any suggestions for further improvements or additional tests are welcome.

Thank you for considering this pull request.