### PR TITLE
Update for VS2022 17.11 compatibility with CUDA < 12.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ if(BUILD_CUDA)
 
         # This is needed to build with VS2022 17.11+ and CUDA < 12.4.
         if (MSVC_VERSION VERSION_GREATER_EQUAL 1941)
-            add_compile_definitions(_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH)
+            string(APPEND CMAKE_CUDA_FLAGS " -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH")
         endif()
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,11 @@ if(BUILD_CUDA)
     # This needs to be added *before* we try to enable the CUDA language so CMake's compiler check passes.
     if(MSVC AND MSVC_VERSION VERSION_GREATER_EQUAL 1940)
         string(APPEND CMAKE_CUDA_FLAGS " --allow-unsupported-compiler")
+
+        # This is needed to build with VS2022 17.11+ and CUDA < 12.4.
+        if (MSVC_VERSION VERSION_GREATER_EQUAL 1941)
+            add_compile_definitions(_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH)
+        endif()
     endif()
 
     enable_language(CUDA) # This will fail if CUDA is not found


### PR DESCRIPTION
The Windows build broke after an update to the MSVC toolchain from 19.40 to 19.41.

This change builds on the workaround added in #1276 for MSVC 19.40 compatibility by additionally defining `_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH`.
 
Reference: microsoft/STL#4475