### PR TITLE
Fix issue that no valid semantic version tag found when installing from source via personal repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ def get_latest_semver_tag():
     tags = subprocess.check_output(["git", "tag"], text=True).splitlines()
     semver_tags = [tag for tag in tags if tag.count(".") == 2 and all(part.isdigit() for part in tag.split("."))]
     if not semver_tags:
-        raise ValueError("No valid semantic version tags found")
+        print("No valid semantic version tags found, use 0.0.1 defaultly")
+        semver_tags = ["0.0.1"]
     return sorted(semver_tags, key=lambda s: list(map(int, s.split("."))))[-1]
 
 


### PR DESCRIPTION
For the `multi-backend-refactor` branch, if we git clone the source code from our personal repository and install it, we will get `ValueError: No valid semantic version tag found`. 

This PR fixes this problem.

cc @Titus-von-Koeller @matthewdouglas

