### PR TITLE
Fix invalid escape sequence warning in Python 3.12

### DIFF
--- a/bitsandbytes/cextension.py
+++ b/bitsandbytes/cextension.py
@@ -45,7 +45,7 @@ def get_cuda_bnb_library_path(cuda_specs: CUDASpecs) -> Path:
 
     override_value = os.environ.get("BNB_CUDA_VERSION")
     if override_value:
-        library_name = re.sub("cuda\d+", f"cuda{override_value}", library_name, count=1)
+        library_name = re.sub(r"cuda\d+", f"cuda{override_value}", library_name, count=1)
         logger.warning(
             f"WARNING: BNB_CUDA_VERSION={override_value} environment variable detected; loading {library_name}.\n"
             "This can be used to load a bitsandbytes version that is different from the PyTorch CUDA version.\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ line-length = 119
 [tool.ruff.lint]
 select = [
     "B",    # bugbear: security warnings
-    "E",    # pycodestyle
+    "E",    # pycodestyle (error)
+    "W",    # pycodestyle (warning)
     "F",    # pyflakes
     "I",    # isort
     "ISC",  # implicit string concatenation


### PR DESCRIPTION
When importing bitsandbytes for the first time in Python 3.12, the following warning is displayed:

```python
$ python -c 'import bitsandbytes'
/home/oshiteku/tmp/.venv/lib/python3.12/site-packages/bitsandbytes/cextension.py:48: SyntaxWarning: invalid escape sequence '\d'
  library_name = re.sub("cuda\d+", f"cuda{override_value}", library_name, count=1)
```

Changes:
- Fix invalid escape sequence in regex pattern
- Add linter configuration to check for invalid escape sequences