### PR TITLE
[Build] Add CUDA 12.6.2 build; update 12.5.0 to 12.5.1

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -64,7 +64,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         arch: [x86_64, aarch64]
         cuda_version:
-          ["11.7.1", "11.8.0", "12.0.1", "12.1.1", "12.2.2", "12.3.2", "12.4.1", "12.5.0"]
+          ["11.7.1", "11.8.0", "12.0.1", "12.1.1", "12.2.2", "12.3.2", "12.4.1", "12.5.1", "12.6.2"]
         exclude:
           - os: windows-latest # This probably requires arm64 Windows agents
             arch: aarch64

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -78,7 +78,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         uses: docker/setup-qemu-action@v2
         # Windows: We install Cuda on the agent (slow)
-      - uses: Jimver/cuda-toolkit@v0.2.16
+      - uses: Jimver/cuda-toolkit@v0.2.19
         if: startsWith(matrix.os, 'windows')
         id: cuda-toolkit
         with:

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -19,7 +19,7 @@ Welcome to the installation guide for the `bitsandbytes` library! This document 
 
 ## CUDA[[cuda]]
 
-`bitsandbytes` is currently only supported on CUDA GPUs for CUDA versions **11.0 - 12.5**. However, there's an ongoing multi-backend effort under development, which is currently in alpha. If you're interested in providing feedback or testing, check out [the multi-backend section below](#multi-backend).
+`bitsandbytes` is currently only supported on CUDA GPUs for CUDA versions **11.0 - 12.6**. However, there's an ongoing multi-backend effort under development, which is currently in alpha. If you're interested in providing feedback or testing, check out [the multi-backend section below](#multi-backend).
 
 ### Supported CUDA Configurations[[cuda-pip]]
 
@@ -29,7 +29,7 @@ The latest version of `bitsandbytes` builds on the following configurations:
 |-------------|------------------|----------------------|
 | **Linux**   | 11.7 - 12.3      | GCC 11.4             |
 |             | 12.4+            | GCC 13.2             |
-| **Windows** | 11.7 - 12.4      | MSVC 19.38+ (VS2022) |
+| **Windows** | 11.7 - 12.6      | MSVC 19.38+ (VS2022) |
 
 For Linux systems, ensure your hardware meets the following requirements:
 
@@ -115,7 +115,7 @@ pip install -e .   # `-e` for "editable" install, when developing BNB (otherwise
 
 Windows systems require Visual Studio with C++ support as well as an installation of the CUDA SDK.
 
-To compile from source, you need CMake >= **3.22.1** and Python >= **3.8** installed. You should also install CUDA Toolkit by following the [CUDA Installation Guide for Windows](https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html) guide from NVIDIA.
+To compile from source, you need CMake >= **3.22.1** and Python >= **3.9** installed. You should also install CUDA Toolkit by following the [CUDA Installation Guide for Windows](https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html) guide from NVIDIA.
 
 Refer to the following table if you're using another CUDA Toolkit version.
 
@@ -150,12 +150,12 @@ Then locally install the CUDA version you need with this script from bitsandbyte
 ```bash
 wget https://raw.githubusercontent.com/bitsandbytes-foundation/bitsandbytes/main/install_cuda.sh
 # Syntax cuda_install CUDA_VERSION INSTALL_PREFIX EXPORT_TO_BASH
-#   CUDA_VERSION in {110, 111, 112, 113, 114, 115, 116, 117, 118, 120, 121, 122, 123, 124, 125}
+#   CUDA_VERSION in {110, 111, 112, 113, 114, 115, 116, 117, 118, 120, 121, 122, 123, 124, 125, 126}
 #   EXPORT_TO_BASH in {0, 1} with 0=False and 1=True
 
-# For example, the following installs CUDA 11.7 to ~/local/cuda-11.7 and exports the path to your .bashrc
+# For example, the following installs CUDA 12.6 to ~/local/cuda-12.6 and exports the path to your .bashrc
 
-bash install_cuda.sh 117 ~/local 1
+bash install_cuda.sh 126 ~/local 1
 ```
 
 2. Set the environment variables `BNB_CUDA_VERSION` and `LD_LIBRARY_PATH` by manually overriding the CUDA version installed by PyTorch.
@@ -171,8 +171,8 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:<PATH>
 For example, to use a local install path:
 
 ```bash
-export BNB_CUDA_VERSION=117
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/YOUR_USERNAME/local/cuda-11.7
+export BNB_CUDA_VERSION=126
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/YOUR_USERNAME/local/cuda-12.6
 ```
 
 3. Now when you launch bitsandbytes with these environment variables, the PyTorch CUDA version is overridden by the new CUDA version (in this example, version 11.7) and a different bitsandbytes library is loaded.

--- a/install_cuda.py
+++ b/install_cuda.py
@@ -18,7 +18,8 @@ cuda_versions = {
     "122": "https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run",
     "123": "https://developer.download.nvidia.com/compute/cuda/12.3.2/local_installers/cuda_12.3.2_545.23.08_linux.run",
     "124": "https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux.run",
-    "125": "https://developer.download.nvidia.com/compute/cuda/12.5.0/local_installers/cuda_12.5.0_555.42.02_linux.run",
+    "125": "https://developer.download.nvidia.com/compute/cuda/12.5.1/local_installers/cuda_12.5.1_555.42.06_linux.run",
+    "126": "https://developer.download.nvidia.com/compute/cuda/12.6.2/local_installers/cuda_12.6.2_560.35.03_linux.run",
 }
 
 

--- a/install_cuda.sh
+++ b/install_cuda.sh
@@ -12,7 +12,8 @@ URL121=https://developer.download.nvidia.com/compute/cuda/12.1.1/local_installer
 URL122=https://developer.download.nvidia.com/compute/cuda/12.2.2/local_installers/cuda_12.2.2_535.104.05_linux.run
 URL123=https://developer.download.nvidia.com/compute/cuda/12.3.2/local_installers/cuda_12.3.2_545.23.08_linux.run
 URL124=https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux.run
-URL125=https://developer.download.nvidia.com/compute/cuda/12.5.0/local_installers/cuda_12.5.0_555.42.02_linux.run
+URL125=https://developer.download.nvidia.com/compute/cuda/12.5.1/local_installers/cuda_12.5.1_555.42.06_linux.run
+URL126=https://developer.download.nvidia.com/compute/cuda/12.6.2/local_installers/cuda_12.6.2_560.35.03_linux.run
 
 CUDA_VERSION=$1
 BASE_PATH=$2
@@ -64,6 +65,9 @@ if [[ -n "$CUDA_VERSION" ]]; then
   elif [[ "$CUDA_VERSION" -eq "125" ]]; then
     URL=$URL125
     FOLDER=cuda-12.5
+  elif [[ "$CUDA_VERSION" -eq "126" ]]; then
+    URL=$URL126
+    FOLDER=cuda-12.6
   else
     echo "argument error: No cuda version passed as input. Choose among versions 110 to 125"
   fi


### PR DESCRIPTION
Adds CUDA 12.6.2 to the build matrix and bumps 12.5.0 to 12.5.1.

See discussion #1399 for request.

Note that PyTorch will be moving to 11.8/12.4/12.6 releases. [Reference](https://github.com/pytorch/pytorch/issues/138609#issuecomment-2491806288)