### PR TITLE
Check input data device type to decide which op should be used

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -481,7 +481,7 @@ class Linear4bit(nn.Linear):
             and not self.training
             and x.requires_grad == False
         ):
-            enable_ipex_fusion(self)
+            enable_ipex_fusion(self, x)
 
     def forward(self, x: torch.Tensor):
         # Check if ipex fusion can be used

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ def get_latest_semver_tag():
     tags = subprocess.check_output(["git", "tag"], text=True).splitlines()
     semver_tags = [tag for tag in tags if tag.count(".") == 2 and all(part.isdigit() for part in tag.split("."))]
     if not semver_tags:
-        print("No valid semantic version tags found, use 0.0.1 defaultly")
-        semver_tags = ["0.0.1"]
+        print("No valid semantic version tags found, use 1.0.0 defaultly")
+        semver_tags = ["1.0.0"]
     return sorted(semver_tags, key=lambda s: list(map(int, s.split("."))))[-1]
 
 


### PR DESCRIPTION
We should enable the correct backend of ipex op based on the input data device.
Set default semver_tags to 1.0.0 because there are some version checks in transformers.