### PR TITLE
Exclude tests from distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,3 +149,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "scipy.stats"
 ignore_missing_imports = true
+
+[tool.setuptools.packages.find]
+exclude = ["tests*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ test = [
 ]
 
 [tool.setuptools]
+packages = ["bitsandbytes"]
 package-data = { "*" = ["libbitsandbytes*.*"] }
 
 [tool.setuptools.dynamic]
@@ -149,6 +150,3 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "scipy.stats"
 ignore_missing_imports = true
-
-[tool.setuptools.packages.find]
-exclude = ["tests*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,10 @@ test = [
 ]
 
 [tool.setuptools]
-packages = ["bitsandbytes"]
 package-data = { "*" = ["libbitsandbytes*.*"] }
+
+[tool.setuptools.packages.find]
+include = ["bitsandbytes*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "bitsandbytes.__version__"}


### PR DESCRIPTION
Fixes #1478.

It could be a good idea to switch to https://hatch.pypa.io/latest/ instead of `setuptools.build_meta` at some point.