### PR TITLE
add xpu device index for `Int8Params`

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -660,9 +660,9 @@ class Int8Params(torch.nn.Parameter):
         self.SCB = SCB
         return self
 
-    def xpu(self):
+    def xpu(self, device):
         # we store the 8-bit rows-major weight
-        B = self.data.contiguous().to(torch.float16).xpu()
+        B = self.data.contiguous().to(torch.float16).xpu(device)
         CB, CBt, SCB, SCBt, coo_tensorB = bnb.functional.double_quant(B)
         if CBt is not None:
             del CBt
@@ -700,11 +700,11 @@ class Int8Params(torch.nn.Parameter):
                 return self.cpu()
         elif device.type == "xpu":
             if self.data.dtype == torch.int8:
-                self.data = self.data.contiguous().xpu()
+                self.data = self.data.contiguous().xpu(device)
                 self.CB = self.data
                 return self
             else:
-                return self.xpu()
+                return self.xpu(device)
         else:
             new_param = Int8Params(
                 super().to(device=device, dtype=dtype, non_blocking=non_blocking),


### PR DESCRIPTION
The following code will not move tensor to the desired `target_device`:

```bash
import torch
import bitsandbytes as bnb

random_tensor = torch.randn((3, 3), dtype=torch.float16)
target_device = 2
new_value = bnb.nn.Int8Params(random_tensor, requires_grad=False).to(target_device)
print(new_value)
# Parameter containing:
# Parameter(Int8Params([[ 127,  -97, -126],
#             [  60,   11,  127],
#             [-127,   90,  -35]], device='xpu:0', dtype=torch.int8))
```

To fix this, we need to pass the device index to the `xpu` method just like in the `cuda` method. 
