### PR TITLE
Update cuda versions in error messages

### DIFF
--- a/install_cuda.sh
+++ b/install_cuda.sh
@@ -69,10 +69,10 @@ if [[ -n "$CUDA_VERSION" ]]; then
     URL=$URL126
     FOLDER=cuda-12.6
   else
-    echo "argument error: No cuda version passed as input. Choose among versions 110 to 125"
+    echo "argument error: No cuda version passed as input. Choose among versions 110 to 126"
   fi
 else
-    echo "argument error: No cuda version passed as input. Choose among versions 110 to 125"
+    echo "argument error: No cuda version passed as input. Choose among versions 110 to 126"
 fi
 
 FILE=$(basename $URL)


### PR DESCRIPTION
Very simple, script supports 126. 
The error message may be misleading to people using the script.