### PR TITLE
Bug fix: Update create_dynamic_map to always return a float32 tensor

### DIFF
--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -389,14 +389,14 @@ def create_dynamic_map(signed=True, max_exponent_bits=7, total_bits=8):
             if signed
             else 2 ** (i + non_sign_bits - max_exponent_bits + 1) + 1,
         )
-        boundaries = torch.linspace(0.1, 1, fraction_items)
+        boundaries = torch.linspace(0.1, 1, fraction_items, dtype=torch.float32)
         means = (boundaries[:-1] + boundaries[1:]) / 2.0
         data += ((10 ** (-(max_exponent_bits - 1) + i)) * means).tolist()
         if signed:
             data += (-(10 ** (-(max_exponent_bits - 1) + i)) * means).tolist()
 
     if additional_items > 0:
-        boundaries = torch.linspace(0.1, 1, additional_items + 1)
+        boundaries = torch.linspace(0.1, 1, additional_items + 1, dtype=torch.float32)
         means = (boundaries[:-1] + boundaries[1:]) / 2.0
         data += ((10 ** (-(max_exponent_bits - 1) + i)) * means).tolist()
         if signed:
@@ -412,7 +412,7 @@ def create_dynamic_map(signed=True, max_exponent_bits=7, total_bits=8):
         data.append(0)
 
     data.sort()
-    return torch.tensor(data)
+    return torch.tensor(data, dtype=torch.float32)
 
 
 def create_quantile_map(A, total_bits=8):


### PR DESCRIPTION
`bitsandbytes.functional.create_dynamic_map` doesn't specify a dtype for the result tensor it creates, so it will use the torch default dtype. However, all of the `cquantize_blockwise_*`/`cdequantize_blockwise_*` functions in pythoninterface.cpp expect a `float *` for `code`. This discrepancy causes `quantize_blockwise` and `dequantize_blockwise` to crash or give incorrect outputs whenever the default torch dtype is modified before `name2qmap["dynamic"]` is created on the first call. (Obviously using `torch.set_default_dtype` isn't necessarily the best practice, but at the time of writing it's still in fairly common use, e.g. https://github.com/meta-llama/llama-models/blob/main/models/llama3/reference_impl/generation.py#L157.)

To reproduce:

```
import torch
from bitsandbytes.functional import quantize_blockwise, name2qmap

torch.manual_seed(42)
X = torch.randn(65536).cuda()
Q1, _ = quantize_blockwise(X)
Q2, _ = quantize_blockwise(X)
torch.testing.assert_close(Q1, Q2)

del name2qmap['dynamic']
torch.set_default_dtype(torch.float16)
Q3, _ = quantize_blockwise(X)
torch.testing.assert_close(Q1, Q3)
```