### PR TITLE
XPU backend support 8bit optimizer

### DIFF
--- a/bitsandbytes/backends/cpu.py
+++ b/bitsandbytes/backends/cpu.py
@@ -35,6 +35,9 @@ class CPUBackend(Backend):
     mm_dequant_compute_dtype = torch.bfloat16
     mm_dequant_output_dtype = torch.bfloat16
 
+    def device_synchronize(self):
+        pass
+
     def int8_double_quant(
         self,
         A: torch.Tensor,

--- a/bitsandbytes/backends/cpu_xpu_common.py
+++ b/bitsandbytes/backends/cpu_xpu_common.py
@@ -60,7 +60,7 @@ def _ipex_xpu_version_prereq(major, minor):
 
 def _maybe_torch_compile(func):
     # torch.compile requires g++ and pytorch >= 2.0
-    if gxx_available and _torch_version_prereq(2, 0) and not ipex_xpu:
+    if gxx_available and _torch_version_prereq(2, 0) and ipex_cpu_only:
         options = {}
         # fx_graph_cache requires pytorch >= 2.2
         if _torch_version_prereq(2, 2):

--- a/bitsandbytes/backends/cuda.py
+++ b/bitsandbytes/backends/cuda.py
@@ -97,6 +97,9 @@ if lib and lib.compiled_with_cuda:
 
 
 class CUDABackend(Backend):
+    def device_synchronize(self):
+        torch.cuda.synchronize()
+
     def transform(
         self,
         A: torch.Tensor,

--- a/bitsandbytes/backends/mps.py
+++ b/bitsandbytes/backends/mps.py
@@ -8,6 +8,9 @@ from .base import Backend
 
 
 class MPSBackend(Backend):
+    def device_synchronize(self):
+        torch.mps.synchronize()
+
     def double_quant(
         self,
         A: torch.Tensor,

--- a/bitsandbytes/backends/npu.py
+++ b/bitsandbytes/backends/npu.py
@@ -29,6 +29,9 @@ def assert_on_npu(tensors):
 
 
 class NPUBackend(Backend):
+    def device_synchronize(self):
+        torch.npu.synchronize()
+
     def int8_double_quant(
         self,
         A: torch.Tensor,

--- a/bitsandbytes/backends/xpu.py
+++ b/bitsandbytes/backends/xpu.py
@@ -13,7 +13,10 @@ from .cpu_xpu_common import (
     int8_mm_dequant_impl,
     quantize_4bit_impl,
 )
-import intel_extension_for_pytorch as ipex
+try:
+    import intel_extension_for_pytorch as ipex
+except BaseException:
+    ipex_xpu = None
 
 Tensor = torch.Tensor
 
@@ -260,7 +263,6 @@ class XPUBackend(Backend):
             raise ValueError(
                 f"Gradient+optimizer bit data type combination not supported: grad {g.dtype}, optimizer {state1.dtype}",
             )
-
         optim_func(
             p,
             g,

--- a/bitsandbytes/backends/xpu.py
+++ b/bitsandbytes/backends/xpu.py
@@ -205,6 +205,9 @@ class XPUBackend(Backend):
         blocksize: int = 4096,
         nested=False,
     ) -> torch.Tensor:
+        if ipex_xpu is None:
+            raise RuntimeError("Please install intel_extension_for_ipex for 8bit optimizer backend on XPU device.")
+
         # void cdequantize_blockwise_fp32(float *code, unsigned char *A, float *absmax, float *out, int blocksize, const int n, cudaStream_t stream)
         if out.dtype == torch.float16:
             ipex.xpu.bitsandbytes.cdequantize_blockwise_fp16(code, A, absmax, out, blocksize, A.numel())

--- a/bitsandbytes/backends/xpu.py
+++ b/bitsandbytes/backends/xpu.py
@@ -13,8 +13,17 @@ from .cpu_xpu_common import (
     int8_mm_dequant_impl,
     quantize_4bit_impl,
 )
+import intel_extension_for_pytorch as ipex
 
 Tensor = torch.Tensor
+
+str2optimizer8bit_blockwise = {
+        "adam": (
+            ipex.xpu.bitsandbytes.cadam_8bit_blockwise_grad_fp32,
+            # lib.cadam_8bit_blockwise_grad_fp16,
+            # lib.cadam_8bit_blockwise_grad_bf16,
+        ),
+    }
 
 
 def assert_on_xpu(tensors):
@@ -34,6 +43,9 @@ def assert_on_xpu(tensors):
 class XPUBackend(Backend):
     mm_dequant_compute_dtype = torch.bfloat16
     mm_dequant_output_dtype = torch.bfloat16
+
+    def device_synchronize(self):
+        torch.xpu.synchronize()
 
     def int8_double_quant(
         self,
@@ -221,7 +233,48 @@ class XPUBackend(Backend):
         gnorm_scale: float = 1.0,
         skip_zeros=False,
     ) -> None:
-        raise NotImplementedError
+        optim_func = None
+
+        # is_on_gpu([g, p, state1, state2, qmap1, qmap2, absmax1, absmax2])
+        if g.dtype == torch.float32 and state1.dtype == torch.uint8:
+            optim_func = str2optimizer8bit_blockwise[optimizer_name][0]
+        # elif g.dtype == torch.float16 and state1.dtype == torch.uint8:
+        #     optim_func = str2optimizer8bit_blockwise[optimizer_name][1]
+        # elif (
+        #     g.dtype == torch.bfloat16
+        #     and state1.dtype == torch.uint8
+        #     and len(str2optimizer8bit_blockwise[optimizer_name]) == 3
+        # ):
+        #     optim_func = str2optimizer8bit_blockwise[optimizer_name][2]
+        # else:
+        #     raise ValueError(
+        #         f"Gradient+optimizer bit data type combination not supported: grad {g.dtype}, optimizer {state1.dtype}",
+        #     )
+
+        # is_on_gpu([p, g, state1, state2, qmap1, qmap2, absmax1, absmax2])
+
+        optim_func(
+            p,
+            g,
+            state1,
+            state2,
+            beta1,
+            beta2,
+            beta3,
+            alpha,
+            eps,
+            step,
+            lr,
+            qmap1,
+            qmap2,
+            absmax1,
+            absmax2,
+            weight_decay,
+            gnorm_scale,
+            skip_zeros,
+            g.numel()
+        )
+
 
     def optimizer_update_32bit(
         self,

--- a/bitsandbytes/backends/xpu.py
+++ b/bitsandbytes/backends/xpu.py
@@ -198,7 +198,16 @@ class XPUBackend(Backend):
         blocksize: int = 4096,
         nested=False,
     ) -> torch.Tensor:
-        raise NotImplementedError
+        # void cdequantize_blockwise_fp32(float *code, unsigned char *A, float *absmax, float *out, int blocksize, const int n, cudaStream_t stream)
+        if out.dtype == torch.float16:
+            ipex.xpu.bitsandbytes.cdequantize_blockwise_fp16(code, A, absmax, out, blocksize, A.numel())
+        elif out.dtype == torch.bfloat16:
+            ipex.xpu.bitsandbytes.cdequantize_blockwise_bf16(code, A, absmax, out, blocksize, A.numel())
+        elif out.dtype == torch.float32:
+            ipex.xpu.bitsandbytes.cdequantize_blockwise_fp32(code, A, absmax, out, blocksize, A.numel())
+        else:
+            raise ValueError(f"Blockwise quantization only supports 16/32-bit floats, but got {out.dtype}")
+        
 
     def quantize_blockwise(
         self,

--- a/bitsandbytes/backends/xpu.py
+++ b/bitsandbytes/backends/xpu.py
@@ -12,6 +12,7 @@ from .cpu_xpu_common import (
     int8_linear_matmul_impl,
     int8_mm_dequant_impl,
     quantize_4bit_impl,
+    _ipex_xpu_version_prereq
 )
 try:
     import intel_extension_for_pytorch as ipex
@@ -23,7 +24,7 @@ Tensor = torch.Tensor
 
 
 str2optimizer8bit_blockwise = {}
-if ipex_xpu is not None:
+if ipex_xpu is not None and _ipex_xpu_version_prereq(2, 7):
     str2optimizer8bit_blockwise = {
             "adam": (
                 ipex.xpu.bitsandbytes.cadam_8bit_blockwise_grad_fp32,
@@ -205,8 +206,8 @@ class XPUBackend(Backend):
         blocksize: int = 4096,
         nested=False,
     ) -> torch.Tensor:
-        if ipex_xpu is None:
-            raise RuntimeError("Please install intel_extension_for_ipex for 8bit optimizer backend on XPU device.")
+        if ipex_xpu is None or not _ipex_xpu_version_prereq(2, 7):
+            raise RuntimeError("Please install intel_extension_for_ipex >= 2.7 for 8bit optimizer backend on XPU device.")
 
         # void cdequantize_blockwise_fp32(float *code, unsigned char *A, float *absmax, float *out, int blocksize, const int n, cudaStream_t stream)
         if out.dtype == torch.float16:
@@ -253,8 +254,8 @@ class XPUBackend(Backend):
         skip_zeros=False,
     ) -> None:
         optim_func = None
-        if ipex_xpu is None:
-            raise RuntimeError("Please install intel_extension_for_ipex for 8bit optimizer backend on XPU device.")
+        if ipex_xpu is None or not _ipex_xpu_version_prereq(2, 7):
+            raise RuntimeError("Please install intel_extension_for_ipex >= 2.7 for 8bit optimizer backend on XPU device.")
 
         assert_on_xpu([g, p, state1, state2, qmap1, qmap2, absmax1, absmax2])
 

--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -859,7 +859,16 @@ def dequantize_blockwise(
     if out is None:
         out = torch.empty(A.shape, dtype=quant_state.dtype, device=A.device)
 
-    if A.device.type != "cpu":
+    if A.device.type == "xpu":
+        backends[A.device.type].dequantize_blockwise(
+            A=A,
+            quant_state=quant_state,
+            absmax=absmax,
+            code=quant_state.code,
+            out=out,
+            blocksize=blocksize,
+            nested=quant_state.nested,)
+    elif A.device.type != "cpu":
         code = quant_state.code.to(A.device)
         supported_blocksizes = [2048, 4096, 1024, 512, 256, 128, 64]
         # Some AMD GPUs have warpsize 64
@@ -871,39 +880,27 @@ def dequantize_blockwise(
                 f"The blocksize of {quant_state.blocksize} is not supported. Supported values: {supported_blocksizes}",
             )
 
-        # is_on_gpu([A, absmax, out])
+        is_on_gpu([A, absmax, out])
 
-        # with _cuda_device_of(A):
-        #     args = (
-        #         get_ptr(quant_state.code),
-        #         get_ptr(A),
-        #         get_ptr(absmax),
-        #         get_ptr(out),
-        #         ct.c_int(quant_state.blocksize),
-        #         ct.c_int(A.numel()),
-        #         _get_tensor_stream(A),
-        #     )
+        with _cuda_device_of(A):
+            args = (
+                get_ptr(quant_state.code),
+                get_ptr(A),
+                get_ptr(absmax),
+                get_ptr(out),
+                ct.c_int(quant_state.blocksize),
+                ct.c_int(A.numel()),
+                _get_tensor_stream(A),
+            )
 
-        #     if out.dtype == torch.float16:
-        #         lib.cdequantize_blockwise_fp16(*args)
-        #     elif out.dtype == torch.bfloat16:
-        #         lib.cdequantize_blockwise_bf16(*args)
-        #     elif out.dtype == torch.float32:
-        #         lib.cdequantize_blockwise_fp32(*args)
-        #     else:
-        #         raise ValueError(f"Blockwise quantization only supports 16/32-bit floats, but got {out.dtype}")
-        
-        ## xpu
-        backends[A.device.type].dequantize_blockwise(
-            A=A,
-            quant_state=quant_state,
-            absmax=absmax,
-            code=quant_state.code,
-            out=out,
-            blocksize=blocksize,
-            nested=quant_state.nested,)
-            
-
+            if out.dtype == torch.float16:
+                lib.cdequantize_blockwise_fp16(*args)
+            elif out.dtype == torch.bfloat16:
+                lib.cdequantize_blockwise_bf16(*args)
+            elif out.dtype == torch.float32:
+                lib.cdequantize_blockwise_fp32(*args)
+            else:
+                raise ValueError(f"Blockwise quantization only supports 16/32-bit floats, but got {out.dtype}")
     else:
         code = quant_state.code.cpu()
         lib.cdequantize_blockwise_cpu_fp32(

--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -871,27 +871,39 @@ def dequantize_blockwise(
                 f"The blocksize of {quant_state.blocksize} is not supported. Supported values: {supported_blocksizes}",
             )
 
-        is_on_gpu([A, absmax, out])
+        # is_on_gpu([A, absmax, out])
 
-        with _cuda_device_of(A):
-            args = (
-                get_ptr(quant_state.code),
-                get_ptr(A),
-                get_ptr(absmax),
-                get_ptr(out),
-                ct.c_int(quant_state.blocksize),
-                ct.c_int(A.numel()),
-                _get_tensor_stream(A),
-            )
+        # with _cuda_device_of(A):
+        #     args = (
+        #         get_ptr(quant_state.code),
+        #         get_ptr(A),
+        #         get_ptr(absmax),
+        #         get_ptr(out),
+        #         ct.c_int(quant_state.blocksize),
+        #         ct.c_int(A.numel()),
+        #         _get_tensor_stream(A),
+        #     )
 
-            if out.dtype == torch.float16:
-                lib.cdequantize_blockwise_fp16(*args)
-            elif out.dtype == torch.bfloat16:
-                lib.cdequantize_blockwise_bf16(*args)
-            elif out.dtype == torch.float32:
-                lib.cdequantize_blockwise_fp32(*args)
-            else:
-                raise ValueError(f"Blockwise quantization only supports 16/32-bit floats, but got {out.dtype}")
+        #     if out.dtype == torch.float16:
+        #         lib.cdequantize_blockwise_fp16(*args)
+        #     elif out.dtype == torch.bfloat16:
+        #         lib.cdequantize_blockwise_bf16(*args)
+        #     elif out.dtype == torch.float32:
+        #         lib.cdequantize_blockwise_fp32(*args)
+        #     else:
+        #         raise ValueError(f"Blockwise quantization only supports 16/32-bit floats, but got {out.dtype}")
+        
+        ## xpu
+        backends[A.device.type].dequantize_blockwise(
+            A=A,
+            quant_state=quant_state,
+            absmax=absmax,
+            code=quant_state.code,
+            out=out,
+            blocksize=blocksize,
+            nested=quant_state.nested,)
+            
+
     else:
         code = quant_state.code.cpu()
         lib.cdequantize_blockwise_cpu_fp32(

--- a/bitsandbytes/optim/optimizer.py
+++ b/bitsandbytes/optim/optimizer.py
@@ -538,6 +538,7 @@ class Optimizer2State(Optimizer8bit):
                 max_unorm=config["max_unorm"],
                 skip_zeros=config["skip_zeros"],
             )
+
         elif state["state1"].dtype == torch.uint8 and not config["block_wise"]:
             F.optimizer_update_8bit(
                 self.optimizer_name,

--- a/bitsandbytes/optim/optimizer.py
+++ b/bitsandbytes/optim/optimizer.py
@@ -10,6 +10,7 @@ from typing import Optional
 import torch
 
 import bitsandbytes.functional as F
+from bitsandbytes.backends import backends
 
 
 class MockArgs:
@@ -289,11 +290,11 @@ class Optimizer8bit(torch.optim.Optimizer):
 
                 self.prefetch_state(p)
                 self.update_step(group, p, gindex, pindex)
-                torch.cuda.synchronize()
+                backends[p.device.type].device_synchronize()
         if self.is_paged:
             # all paged operation are asynchronous, we need
             # to sync to make sure all tensors are in the right state
-            torch.cuda.synchronize()
+            backends[p.device.type].device_synchronize()
 
         return loss
 
@@ -537,7 +538,6 @@ class Optimizer2State(Optimizer8bit):
                 max_unorm=config["max_unorm"],
                 skip_zeros=config["skip_zeros"],
             )
-
         elif state["state1"].dtype == torch.uint8 and not config["block_wise"]:
             F.optimizer_update_8bit(
                 self.optimizer_name,


### PR DESCRIPTION
This pr adds support of 8bit optimizer for XPU backend.
The backend kernels is integrated in Intel_extension_for_pytorch now.
We have verified the whole path accuracy with 8bit Adam blockwise. 

Also add device synchronize func for every backend class to avoid cuda hardcode.

@jiqing-feng  @matthewdouglas @Titus-von-Koeller 

