### PR TITLE
Fix xpu to cpu

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -694,7 +694,7 @@ class Int8Params(torch.nn.Parameter):
     def to(self, *args, **kwargs):
         device, dtype, non_blocking, convert_to_format = torch._C._nn._parse_to(*args, **kwargs)
 
-        if device is not None and device.type in ("cuda", "xpu", "cpu"):
+        if device is not None:
             if device.type == "cuda" and self.data.device.type == "cpu":
                 return self.cuda(device)
             elif device.type == "cpu":
@@ -705,21 +705,18 @@ class Int8Params(torch.nn.Parameter):
                     return self.cpu()
             elif device.type == "xpu":
                 if self.data.dtype == torch.int8:
-                    self.data = self.data.contiguous().xpu(device)
+                    self.data = self.data.contiguous()
                     self.CB = self.data
-                    return self
-                else:
-                    return self.xpu(device)
-        else:
-            new_param = Int8Params(
-                super().to(device=device, dtype=dtype, non_blocking=non_blocking),
-                requires_grad=self.requires_grad,
-                has_fp16_weights=self.has_fp16_weights,
-            )
-            new_param.CB = self.CB
-            new_param.SCB = self.SCB
 
-            return new_param
+        new_param = Int8Params(
+            super().to(device=device, dtype=dtype, non_blocking=non_blocking),
+            requires_grad=self.requires_grad,
+            has_fp16_weights=self.has_fp16_weights,
+        )
+        new_param.CB = self.CB
+        new_param.SCB = self.SCB
+
+        return new_param
 
 
 def maybe_rearrange_weight(state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs):

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -700,13 +700,14 @@ class Int8Params(torch.nn.Parameter):
             elif device.type == "cpu":
                 if self.data.dtype == torch.int8:
                     self.CB = self.data
-                    return self
                 else:
                     return self.cpu()
             elif device.type == "xpu":
                 if self.data.dtype == torch.int8:
                     self.data = self.data.contiguous()
                     self.CB = self.data
+                if self.data.device.type == "cpu":
+                    return self.xpu(device)
 
         new_param = Int8Params(
             super().to(device=device, dtype=dtype, non_blocking=non_blocking),


### PR DESCRIPTION
This PR fixed moving model from xpu to cpu.
Error can be reproduced by the following codes:
```python
import torch
from transformers import AutoModelForCausalLM
from peft import get_peft_model, LoraConfig

model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m", load_in_8bit=True)
model.cpu()
weights_not_cpu = [name for name, p in model.named_parameters() if p.device != torch.device("cpu")]
lora_config = LoraConfig(use_dora=True)
peft_model = get_peft_model(model, lora_config)
print(peft_model)
```

Trace log:
```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, xpu:0 and cpu!
```