### PR TITLE
Fix: Return tuple in get_cuda_version_tuple

### DIFF
--- a/bitsandbytes/cuda_specs.py
+++ b/bitsandbytes/cuda_specs.py
@@ -23,9 +23,9 @@ def get_compute_capabilities() -> list[tuple[int, int]]:
 @lru_cache(None)
 def get_cuda_version_tuple() -> tuple[int, int]:
     if torch.version.cuda:
-        return map(int, torch.version.cuda.split(".")[0:2])
+        return tuple(map(int, torch.version.cuda.split(".")[0:2]))
     elif torch.version.hip:
-        return map(int, torch.version.hip.split(".")[0:2])
+        return tuple(map(int, torch.version.hip.split(".")[0:2]))
 
     return None
 


### PR DESCRIPTION
This PR updates `get_cuda_version_tuple()` to return a tuple instead of a map object.

Due to PR #1544 `get_cuda_version_tuple()` returns a map casuing `python3 -m bitandbytes` to fail.

![bitsandbytes](https://github.com/user-attachments/assets/ffc62837-405b-41fd-a2f7-570f0236bd63)

> Test Environment:
> Proxmox VE 8.2 Host
> Ubuntu 22.04.5 LTS Server VM
> CPU : Intel(R) Core(TM) i7-9750H
> GPU : NVIDIA GeForce GTX 1660 Ti
> ```bash
> $ uname -a
> Linux ubuntu-proxmox 5.15.0-135-generic #146-Ubuntu SMP Sat Feb 15 17:06:22 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
> $ gcc --version
> gcc (Ubuntu 13.1.0-8ubuntu1~22.04) 13.1.0
> ```