### PR TITLE
fix log for ipex

### DIFF
--- a/bitsandbytes/cextension.py
+++ b/bitsandbytes/cextension.py
@@ -116,7 +116,10 @@ try:
 except Exception as e:
     lib = None
     if not is_ipex_available:
-        logger.error(f"Could not load bitsandbytes native library: {e}", exc_info=True)
+        logger.error(
+            f"Could not load bitsandbytes native library: {e}. If you use Intel CPU or XPU, please pip install intel_extension_for_pytorch",
+            exc_info=True,
+        )
         if torch.cuda.is_available():
             logger.warning(
                 f"""


### PR DESCRIPTION
The previous lof info is not clear, we only indicate user didn't have library. But user do not need to build library, they can install ipex if they use Intel CPU or XPU.