### PR TITLE
Stop building for CUDA toolkit < 11.8

### DIFF
--- a/.github/scripts/build-cuda.sh
+++ b/.github/scripts/build-cuda.sh
@@ -8,9 +8,6 @@ set -xeuo pipefail
 # By default, target Maxwell through Hopper.
 build_capability="50;52;60;61;70;75;80;86;89;90"
 
-# CUDA 11.7: Remove sm89 and sm90
-[[ "${cuda_version}" == 11.7.* ]] && build_capability="50;52;60;61;70;75;80;86"
-
 # CUDA 12.8: Add sm100 and sm120; remove sm50 through sm61
 [[ "${cuda_version}" == 12.8.* ]] && build_capability="70;75;80;86;89;90;100;120"
 

--- a/.github/scripts/build-cuda.sh
+++ b/.github/scripts/build-cuda.sh
@@ -8,8 +8,8 @@ set -xeuo pipefail
 # By default, target Maxwell through Hopper.
 build_capability="50;52;60;61;70;75;80;86;89;90"
 
-# CUDA 12.8: Add sm100 and sm120; remove sm50 through sm61
-[[ "${cuda_version}" == 12.8.* ]] && build_capability="70;75;80;86;89;90;100;120"
+# CUDA 12.8: Add sm100 and sm120; remove < sm75 to align with PyTorch 2.7+cu128 minimum
+[[ "${cuda_version}" == 12.8.* ]] && build_capability="75;80;86;89;90;100;120"
 
 [[ "${build_os}" = windows-* ]] && python3 -m pip install ninja
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
             arch: aarch64
           - os: ubuntu-22.04 # Temporary. Takes too long, not ready yet.
             arch: aarch64
-    runs-on: ${{ matrix.os }} # One day, we could run them on native agents. Azure supports this now but it's planned only for Q3 2023 for hosted agents
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup MSVC
@@ -70,13 +70,13 @@ jobs:
           - windows-latest
         arch: [x86_64, aarch64]
         cuda_version:
-          ["11.7.1", "11.8.0", "12.0.1", "12.1.1", "12.2.2", "12.3.2", "12.4.1", "12.5.1", "12.6.3", "12.8.1"]
+          ["11.8.0", "12.0.1", "12.1.1", "12.2.2", "12.3.2", "12.4.1", "12.5.1", "12.6.3", "12.8.1"]
         exclude:
           - os: windows-latest # This probably requires arm64 Windows agents
             arch: aarch64
           - os: ubuntu-22.04 # Temporary. Takes too long, not ready yet.
             arch: aarch64
-    runs-on: ${{ matrix.os }} # One day, we could run them on native agents. Azure supports this now but it's planned only for Q3 2023 for hosted agents
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         # Linux: We use Docker to build cross platform Cuda (aarch64 is built in emulation)
@@ -250,33 +250,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           print-hash: true
-
-#  test:
-#    needs:
-#      - build-wheels
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        include:
-#          - os: ubuntu-latest
-#            arch: x86_64
-#            python-version: "3.8"
-#          - os: windows-latest
-#            arch: x86_64
-#            python-version: "3.8"
-#    runs-on: ${{ matrix.os }}
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: actions/download-artifact@v4
-#        with:
-#          merge-multiple: true
-#          pattern: "bdist_wheel_${{ matrix.os }}_${{ matrix.arch }}*"
-#          path: wheel/
-#      - uses: actions/setup-python@v5
-#        with:
-#          python-version: ${{ matrix.python-version }}
-#          cache: pip
-#      - shell: bash
-#        run: ls -lar wheel/
-#      - run: pip install wheel/*.whl -r requirements-ci.txt
-#      - run: pytest --log-cli-level=DEBUG --continue-on-collection-errors tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,8 @@ if(BUILD_CUDA)
         )
     endif()
 
-    if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "11.0")
-        message(FATAL_ERROR "CUDA Version < 11 is not supported")
+    if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "11.4")
+        message(FATAL_ERROR "CUDA Version < 11.4 is not supported")
     elseif(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "13.0")
         message(FATAL_ERROR "CUDA Version > 12 is not supported")
     endif()
@@ -103,35 +103,20 @@ if(BUILD_CUDA)
     if(CMAKE_VERSION VERSION_LESS "3.23.0")
         message(STATUS "CMake < 3.23.0; determining CUDA architectures supported...")
 
-        # 11.x and 12.x both support these at a minimum.
-        set(CMAKE_CUDA_ARCHITECTURES_ALL 50 52 53 60 61 62 70 72 75 80)
+        # 11.4+ supports these at a minimum.
+        set(CMAKE_CUDA_ARCHITECTURES_ALL 50 52 53 60 61 62 70 72 75 80 86 87)
         set(CMAKE_CUDA_ARCHITECTURES_ALL_MAJOR 50 60 70 80)
-
-        # CUDA 11.1 adds Ampere support for GA102-GA107.
-        if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.1")
-            list(APPEND CMAKE_CUDA_ARCHITECTURES_ALL 86)
-        endif()
-
-        # CUDA 11.4 adds Ampere support for GA10B.
-        if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.4")
-            list(APPEND CMAKE_CUDA_ARCHITECTURES_ALL 87)
-        endif()
 
         # CUDA 11.8 adds support for Ada and Hopper.
         if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.8")
             list(APPEND CMAKE_CUDA_ARCHITECTURES_ALL 89 90)
             list(APPEND CMAKE_CUDA_ARCHITECTURES_ALL_MAJOR 90)
         endif()
-        # CUDA 12.7 adds support for Blackwell B100.
-        if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.7")
-            list(APPEND CMAKE_CUDA_ARCHITECTURES_ALL 100)
-            list(APPEND CMAKE_CUDA_ARCHITECTURES_ALL_MAJOR 100)
-        endif()
 
-        # CUDA 12.8 adds support for RTX 50 Blackwell.
+        # CUDA 12.8 adds support for Blackwell.
         if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "12.8")
-            list(APPEND CMAKE_CUDA_ARCHITECTURES_ALL 101 120)
-            list(APPEND CMAKE_CUDA_ARCHITECTURES_ALL_MAJOR 101 120)
+            list(APPEND CMAKE_CUDA_ARCHITECTURES_ALL 100 101 120)
+            list(APPEND CMAKE_CUDA_ARCHITECTURES_ALL_MAJOR 100 120)
         endif()
     endif()
 

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -27,9 +27,9 @@ The latest version of the distributed `bitsandbytes` package is built with the f
 
 | **OS**      | **CUDA Toolkit** | **Host Compiler**         |
 |-------------|------------------|----------------------|
-| **Linux**   | 11.7 - 12.3      | GCC 11.4             |
+| **Linux**   | 11.8 - 12.3      | GCC 11.4             |
 |             | 12.4 - 12.8      | GCC 13.2             |
-| **Windows** | 11.7 - 12.8      | MSVC 19.42+ (VS2022) |
+| **Windows** | 11.8 - 12.8      | MSVC 19.42+ (VS2022) |
 
 For CUDA systems, ensure your hardware meets the following requirements:
 
@@ -88,17 +88,7 @@ For example, to install a compiler and CMake on Ubuntu:
 apt-get install -y build-essential cmake
 ```
 
-You should also install CUDA Toolkit by following the [NVIDIA CUDA Installation Guide for Linux](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html) guide from NVIDIA. The current expected CUDA Toolkit version is **11.1+** and it is recommended to install **GCC >= 7.3** and required to have at least **GCC >= 6**.
-
-Refer to the following table if you're using another CUDA Toolkit version.
-
-| CUDA Toolkit |  GCC  |
-|--------------|-------|
-| >= 11.4.1    | >= 11 |
-| >= 12.0      | >= 12 |
-| >= 12.4      | >= 13 |
-
-Now to install the bitsandbytes package from source, run the following commands:
+You should also install CUDA Toolkit by following the [NVIDIA CUDA Installation Guide for Linux](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html) guide from NVIDIA. The current minimum supported CUDA Toolkit version is **11.8**.
 
 ```bash
 git clone https://github.com/bitsandbytes-foundation/bitsandbytes.git && cd bitsandbytes/
@@ -115,13 +105,7 @@ pip install -e .   # `-e` for "editable" install, when developing BNB (otherwise
 
 Windows systems require Visual Studio with C++ support as well as an installation of the CUDA SDK.
 
-To compile from source, you need CMake >= **3.22.1** and Python >= **3.9** installed. You should also install CUDA Toolkit by following the [CUDA Installation Guide for Windows](https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html) guide from NVIDIA.
-
-Refer to the following table if you're using another CUDA Toolkit version.
-
-| CUDA Toolkit | MSVC |
-|---|---|
-| >= 11.6 | 19.30+ (VS2022) |
+To compile from source, you need CMake >= **3.22.1** and Python >= **3.9** installed. You should also install CUDA Toolkit by following the [CUDA Installation Guide for Windows](https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html) guide from NVIDIA. The current minimum supported CUDA Toolkit version is **11.8**.
 
 ```bash
 git clone https://github.com/bitsandbytes-foundation/bitsandbytes.git && cd bitsandbytes/
@@ -149,7 +133,7 @@ Then locally install the CUDA version you need with this script from bitsandbyte
 ```bash
 wget https://raw.githubusercontent.com/bitsandbytes-foundation/bitsandbytes/main/install_cuda.sh
 # Syntax cuda_install CUDA_VERSION INSTALL_PREFIX EXPORT_TO_BASH
-#   CUDA_VERSION in {110, 111, 112, 113, 114, 115, 116, 117, 118, 120, 121, 122, 123, 124, 125, 126, 128}
+#   CUDA_VERSION in {118, 120, 121, 122, 123, 124, 125, 126, 128}
 #   EXPORT_TO_BASH in {0, 1} with 0=False and 1=True
 
 # For example, the following installs CUDA 12.6 to ~/local/cuda-12.6 and exports the path to your .bashrc

--- a/install_cuda.py
+++ b/install_cuda.py
@@ -4,14 +4,6 @@ import sys
 from urllib.request import urlretrieve
 
 cuda_versions = {
-    "110": "https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run",
-    "111": "https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/cuda_11.1.1_455.32.00_linux.run",
-    "112": "https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux.run",
-    "113": "https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux.run",
-    "114": "https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_470.82.01_linux.run",
-    "115": "https://developer.download.nvidia.com/compute/cuda/11.5.2/local_installers/cuda_11.5.2_495.29.05_linux.run",
-    "116": "https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux.run",
-    "117": "https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_linux.run",
     "118": "https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run",
     "120": "https://developer.download.nvidia.com/compute/cuda/12.0.1/local_installers/cuda_12.0.1_525.85.12_linux.run",
     "121": "https://developer.download.nvidia.com/compute/cuda/12.1.1/local_installers/cuda_12.1.1_530.30.02_linux.run",

--- a/install_cuda.sh
+++ b/install_cuda.sh
@@ -1,11 +1,3 @@
-URL110=https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run
-URL111=https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/cuda_11.1.1_455.32.00_linux.run
-URL112=https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux.run
-URL113=https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux.run
-URL114=https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_470.82.01_linux.run
-URL115=https://developer.download.nvidia.com/compute/cuda/11.5.2/local_installers/cuda_11.5.2_495.29.05_linux.run
-URL116=https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux.run
-URL117=https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_linux.run
 URL118=https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run
 URL120=https://developer.download.nvidia.com/compute/cuda/12.0.1/local_installers/cuda_12.0.1_525.85.12_linux.run
 URL121=https://developer.download.nvidia.com/compute/cuda/12.1.1/local_installers/cuda_12.1.1_530.30.02_linux.run
@@ -20,31 +12,7 @@ BASE_PATH=$2
 EXPORT_BASHRC=$3
 
 if [[ -n "$CUDA_VERSION" ]]; then
-  if   [[ "$CUDA_VERSION" -eq "110" ]]; then
-    URL=$URL110
-    FOLDER=cuda-11.0
-  elif [[ "$CUDA_VERSION" -eq "111" ]]; then
-    URL=$URL111
-    FOLDER=cuda-11.1
-  elif [[ "$CUDA_VERSION" -eq "112" ]]; then
-    URL=$URL112
-    FOLDER=cuda-11.2
-  elif [[ "$CUDA_VERSION" -eq "113" ]]; then
-    URL=$URL113
-    FOLDER=cuda-11.3
-  elif [[ "$CUDA_VERSION" -eq "114" ]]; then
-    URL=$URL114
-    FOLDER=cuda-11.4
-  elif [[ "$CUDA_VERSION" -eq "115" ]]; then
-    URL=$URL115
-    FOLDER=cuda-11.5
-  elif [[ "$CUDA_VERSION" -eq "116" ]]; then
-    URL=$URL116
-    FOLDER=cuda-11.6
-  elif [[ "$CUDA_VERSION" -eq "117" ]]; then
-    URL=$URL117
-    FOLDER=cuda-11.7
-  elif [[ "$CUDA_VERSION" -eq "118" ]]; then
+  if [[ "$CUDA_VERSION" -eq "118" ]]; then
     URL=$URL118
     FOLDER=cuda-11.8
   elif [[ "$CUDA_VERSION" -eq "120" ]]; then
@@ -69,10 +37,10 @@ if [[ -n "$CUDA_VERSION" ]]; then
     URL=$URL126
     FOLDER=cuda-12.6
   else
-    echo "argument error: No cuda version passed as input. Choose among versions 110 to 126"
+    echo "argument error: No cuda version passed as input. Choose among versions 118 to 126"
   fi
 else
-    echo "argument error: No cuda version passed as input. Choose among versions 110 to 126"
+    echo "argument error: No cuda version passed as input. Choose among versions 118 to 126"
 fi
 
 FILE=$(basename $URL)


### PR DESCRIPTION
#1544 set the new PyTorch minimum version of 2.2.0. We wish to align with the standard PyTorch distribution, which ships with CUDA 11.8 builds as the minimum by default from 2.1.

This change helps reduce maintenance burden in addition to keeping our binary sizes in check.

Building from source with older versions of the CUDA toolkit is still feasible, but will no longer be officially supported.