### PR TITLE
Set up nightly CI for unit tests

### DIFF
--- a/.github/scripts/build-cuda.sh
+++ b/.github/scripts/build-cuda.sh
@@ -6,14 +6,14 @@ declare cuda_targets
 
 set -xeuo pipefail
 
-if [ -n "${cuda_targets}" ]; then
+if [[ -v cuda_targets ]; then
+    build_capability="${cuda_targets}"
+else
     # By default, target Maxwell through Hopper.
     build_capability="50;52;60;61;70;75;80;86;89;90"
 
     # CUDA 12.8: Add sm100 and sm120; remove < sm75 to align with PyTorch 2.7+cu128 minimum
     [[ "${cuda_version}" == 12.8.* ]] && build_capability="75;80;86;89;90;100;120"
-else
-    build_capability="${cuda_targets}"
 fi
 
 [[ "${build_os}" = windows-* ]] && python3 -m pip install ninja

--- a/.github/scripts/build-cuda.sh
+++ b/.github/scripts/build-cuda.sh
@@ -6,7 +6,7 @@ declare cuda_targets
 
 set -xeuo pipefail
 
-if [[ -v cuda_targets ]; then
+if [[ -v cuda_targets ]]; then
     build_capability="${cuda_targets}"
 else
     # By default, target Maxwell through Hopper.

--- a/.github/scripts/build-cuda.sh
+++ b/.github/scripts/build-cuda.sh
@@ -2,14 +2,19 @@
 declare build_arch
 declare build_os
 declare cuda_version
+declare cuda_targets
 
 set -xeuo pipefail
 
-# By default, target Maxwell through Hopper.
-build_capability="50;52;60;61;70;75;80;86;89;90"
+if [ -n "${cuda_targets}" ]; then
+    # By default, target Maxwell through Hopper.
+    build_capability="50;52;60;61;70;75;80;86;89;90"
 
-# CUDA 12.8: Add sm100 and sm120; remove < sm75 to align with PyTorch 2.7+cu128 minimum
-[[ "${cuda_version}" == 12.8.* ]] && build_capability="75;80;86;89;90;100;120"
+    # CUDA 12.8: Add sm100 and sm120; remove < sm75 to align with PyTorch 2.7+cu128 minimum
+    [[ "${cuda_version}" == 12.8.* ]] && build_capability="75;80;86;89;90;100;120"
+else
+    build_capability="${cuda_targets}"
+fi
 
 [[ "${build_os}" = windows-* ]] && python3 -m pip install ninja
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [testing-ci]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 
@@ -31,7 +34,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: lib_cpu_${{ matrix.os }}_${{ matrix.arch }}
-          path: output/*
+          path: output/${{ matrix.os }}/${{ matrix.arch }}/*
           retention-days: 7
 
   build-cuda:
@@ -72,7 +75,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: lib_cuda_${{matrix.cuda_version}}_${{ matrix.os }}_${{ matrix.arch }}
-          path: output/*
+          path: output/${{ matrix.os }}/${{ matrix.arch }}/*
           retention-days: 7
 
   cpu-tests:
@@ -87,15 +90,6 @@ jobs:
     env:
       BNB_TEST_DEVICE: cpu
     steps:
-      - name: Show CPU Information
-        shell: bash
-        run: |
-          if [[ $RUNNER_OS == 'Linux' ]]; then
-            lscpu
-          else
-            systeminfo | findstr /C:"Processor"
-          fi
-
       - uses: actions/checkout@v4
 
       - name: Download build artifact
@@ -153,6 +147,10 @@ jobs:
           name: lib_cuda_${{ matrix.cuda_version }}_${{ matrix.os }}_${{ matrix.arch }}
           path: bitsandbytes/
           merge-multiple: true
+
+      - name: Show files
+        run: ls -lR .
+        shell: bash
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,11 +2,14 @@ name: Unit tests
 
 on:
   workflow_dispatch:
+  schedule:
+    # Every day at 02:15 AM UTC
+    - cron: "15 2 * * *"
   push:
     branches: [testing-ci]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -123,13 +126,13 @@ jobs:
       matrix:
         os: [ubuntu-22.04, windows-2025]
         arch: [x86_64]
-        torch_version: ["2.4.1", "2.7.0"]
+        cuda_version: ["11.8.0", "12.8.1"]
         include:
-          - torch_version: "2.4.1"
-            cuda_version: "11.8.0"
+          - cuda_version: "11.8.0"
+            torch_version: "2.4.1"
             pypi_index: "https://download.pytorch.org/whl/cu118"
-          - torch_version: "2.7.0"
-            cuda_version: "12.8.1"
+          - cuda_version: "12.8.1"
+            torch_version: "2.7.0"
             pypi_index: "https://download.pytorch.org/whl/cu128"
     runs-on:
       labels: ${{ contains(matrix.os, 'windows') && 'CUDA-Windows-x64' || 'CUDA-Linux-x64' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,6 +134,11 @@ jobs:
           - cuda_version: "12.8.1"
             torch_version: "2.7.0"
             pypi_index: "https://download.pytorch.org/whl/cu128"
+        exclude:
+          # Our current T4 Windows runner has a driver too old (471.11)
+          # and cannot support CUDA 12+. Skip for now.
+          - os: windows-2025
+            cuda_version: "12.8.1"
     runs-on:
       labels: ${{ contains(matrix.os, 'windows') && 'CUDA-Windows-x64' || 'CUDA-Linux-x64' }}
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Unit tests
 
 on:
   workflow_dispatch:
+  push:
+    branches: [testing-ci]
 
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, windows-2025]
         arch: [x86_64]
-        torch_version: ["2.4.1", "2.7.0"]
+        torch_version: ["2.7.0"]
     runs-on: ${{ matrix.os }}
     env:
       BNB_TEST_DEVICE: cpu
@@ -147,10 +147,6 @@ jobs:
           name: lib_cuda_${{ matrix.cuda_version }}_${{ matrix.os }}_${{ matrix.arch }}
           path: bitsandbytes/
           merge-multiple: true
-
-      - name: Show files
-        run: ls -lR .
-        shell: bash
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,172 @@
+name: Unit tests
+
+on:
+  workflow_dispatch:
+
+
+jobs:
+
+  build-cpu:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, windows-2025]
+        arch: [x86_64]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup MSVC
+        if: startsWith(matrix.os, 'windows')
+        uses: ilammy/msvc-dev-cmd@v1.13.0 # to use cl
+
+      - name: Build C++
+        run: bash .github/scripts/build-cpu.sh
+        env:
+          build_os: ${{ matrix.os }}
+          build_arch: ${{ matrix.arch }}
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lib_cpu_${{ matrix.os }}_${{ matrix.arch }}
+          path: output/*
+          retention-days: 7
+
+  build-cuda:
+    strategy:
+      matrix:
+        cuda_version: ["11.8.0", "12.8.1"]
+        include:
+          - os: ubuntu-22.04
+            arch: x86_64
+          - os: windows-2025
+            arch: x86_64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install CUDA Toolkit
+        uses: Jimver/cuda-toolkit@v0.2.23
+        if: startsWith(matrix.os, 'windows')
+        id: cuda-toolkit
+        with:
+          cuda: ${{ matrix.cuda_version }}
+          method: "network"
+          sub-packages: '["nvcc","cudart","cusparse","cublas","thrust","nvrtc_dev","cublas_dev","cusparse_dev"]'
+
+      - name: Setup MSVC
+        if: startsWith(matrix.os, 'windows')
+        uses: ilammy/msvc-dev-cmd@v1.13.0 # to use cl
+
+      # We're running on T4 only for now, so we only target sm75.
+      - name: Build C++ / CUDA
+        run: bash .github/scripts/build-cuda.sh
+        env:
+          build_os: ${{ matrix.os }}
+          build_arch: x86_64
+          cuda_version: ${{ matrix.cuda_version }}
+          cuda_targets: "75"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lib_cuda_${{matrix.cuda_version}}_${{ matrix.os }}_${{ matrix.arch }}
+          path: output/*
+          retention-days: 7
+
+  cpu-tests:
+    needs: build-cpu
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-2025]
+        arch: [x86_64]
+        torch_version: ["2.4.1", "2.7.0"]
+    runs-on: ${{ matrix.os }}
+    env:
+      BNB_TEST_DEVICE: cpu
+    steps:
+      - name: Show CPU Information
+        run: |
+          if [[ $RUNNER_OS == 'Linux' ]]; then
+            lscpu
+          else
+            systeminfo | findstr /C:"Processor"
+          fi
+
+      - uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: lib_cpu_${{ matrix.os }}_${{ matrix.arch }}
+          path: bitsandbytes/
+          merge-multiple: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          pip install torch==${{ matrix.torch_version }} --index-url https://download.pytorch.org/whl/cpu
+          pip install -e ".[test]"
+          pip install pytest-cov
+
+      - name: Show installed packages
+        run: pip list
+
+      - name: Run tests
+        run: pytest
+
+  cuda-tests:
+    needs: build-cuda
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-2025]
+        arch: [x86_64]
+        torch_version: ["2.4.1", "2.7.0"]
+        include:
+          - torch_version: "2.4.1"
+            cuda_version: "11.8.0"
+            pypi_index: "https://download.pytorch.org/whl/cu118"
+          - torch_version: "2.7.0"
+            cuda_version: "12.8.1"
+            pypi_index: "https://download.pytorch.org/whl/cu128"
+    runs-on:
+      labels: ${{ contains(matrix.os, 'windows') && 'CUDA-Windows-x64' || 'CUDA-Linux-x64' }}
+    env:
+      BNB_TEST_DEVICE: cuda
+    steps:
+      - name: Show GPU Information
+        run: nvidia-smi
+
+      - uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: lib_cuda_${{ matrix.cuda_version }}_${{ matrix.os }}_${{ matrix.arch }}
+          path: bitsandbytes/
+          merge-multiple: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          pip install torch==${{ matrix.torch_version }} --index-url ${{ matrix.pypi_index }}
+          pip install -e ".[test]"
+          pip install pytest-cov
+
+      - name: Show installed packages
+        run: pip list
+
+      - name: Run tests
+        run: pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,12 +38,8 @@ jobs:
     strategy:
       matrix:
         cuda_version: ["11.8.0", "12.8.1"]
-        include:
-          - os: ubuntu-22.04
-            arch: x86_64
-          - os: windows-2025
-            arch: x86_64
-
+        os: [ubuntu-22.04, windows-2025]
+        arch: [x86_64]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -57,6 +53,7 @@ jobs:
           cuda: ${{ matrix.cuda_version }}
           method: "network"
           sub-packages: '["nvcc","cudart","cusparse","cublas","thrust","nvrtc_dev","cublas_dev","cusparse_dev"]'
+          use-github-cache: false
 
       - name: Setup MSVC
         if: startsWith(matrix.os, 'windows')
@@ -91,6 +88,7 @@ jobs:
       BNB_TEST_DEVICE: cpu
     steps:
       - name: Show CPU Information
+        shell: bash
         run: |
           if [[ $RUNNER_OS == 'Linux' ]]; then
             lscpu

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1,6 +1,7 @@
 import os
 from os.path import join
 import shutil
+import sys
 import time
 import uuid
 
@@ -168,6 +169,9 @@ optimizer_names_32bit = [
 @pytest.mark.parametrize("dim1", [1024], ids=id_formatter("dim1"))
 @pytest.mark.parametrize("dim2", [32, 1024, 4097, 1], ids=id_formatter("dim2"))
 def test_optimizer32bit(requires_cuda, dim1, dim2, gtype, optim_name):
+    if optim_name.startswith("paged_") and sys.platform == "win32":
+        pytest.skip("Paged optimizers can have issues on Windows.")
+
     if gtype == torch.bfloat16 and optim_name in ["momentum", "rmsprop"]:
         pytest.skip()
     if dim1 == 1 and dim2 == 1:


### PR DESCRIPTION
This PR establishes a new nightly workflow via GitHub actions which will run our unit test suite. The workflow will be triggers at 02:15 UTC daily.

Builds are completed for these platforms using standard GitHub runners:
* Linux x86-64
  * CPU
  * CUDA 11.8.0, targeting SM75
  * CUDA 12.8.0, targeting SM75
* Windows x86-64
  * CPU
  * CUDA 11.8.0, targeting SM75
  * CUDA 12.8.1, targeting SM75

Unit tests are executed with our minimum Python version requirement of 3.9.
* Linux x86-64
  * CPU: PyTorch 2.7.0+cpu
  * CUDA 11.8.0: PyTorch 2.4.1+cu118 on NVIDIA T4
  * CUDA 12.8.1: PyTorch 2.7.0+cu128 on NVIDIA T4
* Windows x86-64
  * CPU: PyTorch 2.7.0+cpu
  * CUDA 11.8.0: PyTorch 2.4.1+cu118 on NVIDIA T4

Minor adjustments to the test suite are made to limit the runtime of the CPU tests. The paged optimizer tests will be skipped for now on Windows as well.
