### PR TITLE
Update compute_type_is_set attribute for Linear4bit

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -447,7 +447,7 @@ class Linear4bit(nn.Linear):
         )
         # self.persistent_buffers = []  # TODO consider as way to save quant state
         self.compute_dtype = compute_dtype
-        self.compute_type_is_set = False
+        self.compute_type_is_set = False if compute_dtype is None else True
         self.ipex_linear_is_set = False
         self.quant_state = None
         self.quant_storage = quant_storage


### PR DESCRIPTION
**Issue**: If the input to the forward of Linear4bit is torch.float32 dtype and compute_dtype is set to torch.bfloat16 dtype, then the matmul operation executes in torch.float32 dtype. This issue reproduces on CPU and HPU (Intel Gaudi). 

**Fix**: During initialization, compute_type_is_set is set to False. In the forward pass, compute_dtype is set as per the input of the forward pass. Initializing compute_type_is_set as updated in this PR resolves this issue (and we can get rid of unnecessary casting operations)

**Details**: 

**Case I**: No change
1) In the end of [Linear4bit forward](https://github.com/bitsandbytes-foundation/bitsandbytes/blob/multi-backend-refactor/bitsandbytes/nn/modules.py#L530), the x dtype is float32 and weight dtype is uint8
2) From here, control goes to [MatMul4bit forward](https://github.com/bitsandbytes-foundation/bitsandbytes/blob/multi-backend-refactor/bitsandbytes/autograd/_functions.py#L478), 
     a) First, we are dequantizing the weights, output is bfloat16 dtype
     b) Then we are casting the dequantized weights as per input (which is in float32)
     c) and now, we use torch.nn.functional.linear

**Case II**: Using this change
1) Because compute_type_is_set is True, we'll not update the compute_dtype as per the input to the forward
2) Now, input (x) will be [typecasted](https://github.com/bitsandbytes-foundation/bitsandbytes/blob/multi-backend-refactor/bitsandbytes/nn/modules.py#L526) to compute_dtype (which is bfloat16). 
3) In the end of [Linear4bit forward](https://github.com/bitsandbytes-foundation/bitsandbytes/blob/multi-backend-refactor/bitsandbytes/nn/modules.py#L530), the x dtype is bfloat16 and weight dtype is uint8
2) From here, control goes to [MatMul4bit forward](https://github.com/bitsandbytes-foundation/bitsandbytes/blob/multi-backend-refactor/bitsandbytes/autograd/_functions.py#L478), 
     a) First, we are dequantizing the weights, output is bfloat16 dtype
     b) Then we are casting the dequantized weights as per input (which is in bfloat16)
     c) and now, we use torch.nn.functional.linear and both the inputs and weights are in bfloat16 dtype