### PR TITLE
Add CPU + IPEX to nightly CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,6 +161,46 @@ jobs:
       - name: Run tests
         run: pytest --durations=100
 
+  test-cpu-ipex:
+    if: github.repository == 'bitsandbytes-foundation/bitsandbytes'
+    needs: build-cpu
+    runs-on: banb-aws-general-8-plus-use1-public-80
+    env:
+      BNB_TEST_DEVICE: cpu
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: lib_cpu_ubuntu-22.04_x86_64
+          path: bitsandbytes/
+          merge-multiple: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          pip install torch==2.7.0 --index-url https://download.pytorch.org/whl/cpu
+          pip install intel_extension_for_pytorch==2.7.0 -extra-index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
+          pip install -e ".[test]"
+          pip install pytest-cov
+
+      - name: Show installed packages
+        run: pip list
+
+      - name: Show environment information
+        run: python -m torch.utils.collect_env
+
+      - name: IPEX smoke test
+        run: python -c "import torch; import intel_extension_for_pytorch as ipex; print(torch.__version__); print(ipex.__version__);"
+
+      - name: Run tests
+        run: pytest --durations=100
+
   # test-cuda-aarch64:
   #   if: github.repository == 'bitsandbytes-foundation/bitsandbytes'
   #   needs: build-cuda
@@ -181,8 +221,6 @@ jobs:
 
   #     - name: Show pip packages
   #       run: pip list
-
-
 
   test-cuda:
     if: github.repository == 'bitsandbytes-foundation/bitsandbytes'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install torch==2.7.0 --index-url https://download.pytorch.org/whl/cpu
-          pip install intel_extension_for_pytorch==2.7.0 -extra-index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
+          pip install intel_extension_for_pytorch==2.7.0 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
           pip install -e ".[test]"
           pip install pytest-cov
 

--- a/tests/test_linear8bitlt.py
+++ b/tests/test_linear8bitlt.py
@@ -271,11 +271,14 @@ def test_linear8bitlt_torch_compile(device, threshold, bias, fullgraph, mode):
 
         # Test with gradients. Currently only works with threshold=0.
         # Has a strange regression on Linux aarch64 CPU in torch==2.6.0.
+        # There is also an issue with torch==2.7.0 on x86-64 with IPEX.
         is_broken_platform = (
             device == "cpu"
-            and platform.machine() == "aarch64"
             and platform.system() == "Linux"
-            and ((2, 7) > torch.__version__ >= (2, 6))
+            and (
+                (platform.machine() == "aarch64" and (2, 6) <= torch.__version__ < (2, 7))
+                or (platform.machine() == "x86_64" and bnb.functional.ipex_cpu)
+            )
         )
 
         if threshold == 0 and not is_broken_platform:


### PR DESCRIPTION
This PR adds a job to run the test suite with torch 2.7.0 and ipex 2.7.0 on a Linux x86-64 runner, so that we can cover with IPEX-specific optimizations enabled as introduced in #1628. 