### PR TITLE
Add clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,28 @@
+---
+BasedOnStyle: LLVM
+AlignAfterOpenBracket: BlockIndent
+BinPackArguments: true
+BinPackParameters: true
+BracedInitializerIndentWidth: 4
+ColumnLimit: 120
+Cpp11BracedListStyle: true
+IndentWidth: 4
+IndentWrappedFunctionNames: true
+PointerAlignment: Left
+SeparateDefinitionBlocks: Always
+Standard: c++17
+StatementMacros:
+  - 'MAKE_PreconditionOptimizer32bit1State'
+  - 'MAKE_PreconditionOptimizer32bit2State'
+  - 'MAKE_PreconditionStatic8bit1State'
+  - 'MAKE_PreconditionStatic8bit2State'
+  - 'MAKE_Optimizer32bit1State'
+  - 'MAKE_optimizerStatic8bit1State'
+  - 'MAKE_optimizerStatic8bit2State'
+  - 'MAKE_OptimizerStatic8bit1StateBlockwise'
+  - 'MAKE_OptimizerStatic8bit2StateBlockwise'
+  - 'MAKE_kQuantizeBlockwise'
+
+UseTab: Never
+
+...

--- a/.clang-format
+++ b/.clang-format
@@ -22,6 +22,14 @@ StatementMacros:
   - 'MAKE_OptimizerStatic8bit1StateBlockwise'
   - 'MAKE_OptimizerStatic8bit2StateBlockwise'
   - 'MAKE_kQuantizeBlockwise'
+  - 'MAKE_BLOCKWISE8'
+  - 'MAKE_ELEMENTWISE_FUNC'
+  - 'CMAKE_ELEMENTWISE_FUNC'
+  - 'MAKE_FUNC8'
+  - 'MAKE_FUNC32'
+  - 'MAKE_CBLOCKWISE8'
+  - 'MAKE_CFUNC8'
+  - 'MAKE_CFUNC32'
 
 UseTab: Never
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,9 @@ repos:
     rev: v1.26.0
     hooks:
       - id: typos
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v20.1.6
+    hooks:
+    - id: clang-format
+      types_or: [c++, c, cuda]
+      files: ^csrc/


### PR DESCRIPTION
This PR adds an initial set of [clang-format](https://clang.llvm.org/docs/ClangFormat.html) rules for C/C++/CUDA code, and a pre-commit hook to check these rules.