### PR TITLE
CI: Test with PyTorch 2.8.0 RC

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,8 +101,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2025, macos-15]
-        # Test with the oldest supported torch version and the two newest.
-        torch_version: ["2.2.2", "2.6.0", "2.7.1"]
+        # Test with the oldest supported torch version, the newest stable, current RC, and nightly.
+        torch_version: ["2.2.2", "2.7.1", "2.8.0", "2.9.0"]
         include:
           - os: ubuntu-22.04
             arch: x86_64
@@ -144,7 +144,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install torch==${{ matrix.torch_version }} --index-url https://download.pytorch.org/whl/cpu
+          pip install torch~=${{ matrix.torch_version }}.dev0 --index-url https://download.pytorch.org/whl/${{ (matrix.torch_version == '2.8.0' && 'test/cpu') || (matrix.torch_version == '2.9.0' && 'nightly/cpu') || '/cpu' }}
           pip install -e ".[test]"
           pip install pytest-cov
 
@@ -372,6 +372,9 @@ jobs:
             pypi_index: "https://download.pytorch.org/whl/cu128"
           - cuda_version: "12.9.1"
             torch_version: "2.8.0"
+            pypi_index: "https://download.pytorch.org/whl/test/cu129"
+          - cuda_version: "12.9.1"
+            torch_version: "2.9.0"
             pypi_index: "https://download.pytorch.org/whl/nightly/cu129"
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install torch~=${{ matrix.torch_version }}.dev0 --index-url https://download.pytorch.org/whl/${{ (matrix.torch_version == '2.8.0' && 'test/cpu') || (matrix.torch_version == '2.9.0' && 'nightly/cpu') || '/cpu' }}
+          pip install torch~=${{ matrix.torch_version }}.dev0 --index-url https://download.pytorch.org/whl/${{ (matrix.torch_version == '2.8.0' && 'test/cpu') || (matrix.torch_version == '2.9.0' && 'nightly/cpu') || 'cpu' }}
           pip install -e ".[test]"
           pip install pytest-cov
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,8 +101,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2025, macos-15]
-        # Test with the oldest supported torch version, the newest stable, current RC, and nightly.
-        torch_version: ["2.2.2", "2.7.1", "2.8.0", "2.9.0"]
+        # Test with the oldest supported torch version, the newest two stable/RC.
+        torch_version: ["2.2.2", "2.7.1", "2.8.0"]
         include:
           - os: ubuntu-22.04
             arch: x86_64
@@ -144,7 +144,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install torch~=${{ matrix.torch_version }}.dev0 --index-url https://download.pytorch.org/whl/${{ (matrix.torch_version == '2.8.0' && 'test/cpu') || (matrix.torch_version == '2.9.0' && 'nightly/cpu') || 'cpu' }}
+          pip install torch==${{ matrix.torch_version }} --index-url https://download.pytorch.org/whl/${{ (matrix.torch_version == '2.8.0' && 'test/cpu') || 'cpu' }}
           pip install -e ".[test]"
           pip install pytest-cov
 
@@ -373,9 +373,6 @@ jobs:
           - cuda_version: "12.9.1"
             torch_version: "2.8.0"
             pypi_index: "https://download.pytorch.org/whl/test/cu129"
-          - cuda_version: "12.9.1"
-            torch_version: "2.9.0"
-            pypi_index: "https://download.pytorch.org/whl/nightly/cu129"
 
 
           # Linux L40S runners


### PR DESCRIPTION
Updates CI workflow for CPU and CUDA to test against the RC version of torch 2.8.0.