### PR TITLE
[XPU] Implemented 32bit optimizers in triton

### DIFF
--- a/bitsandbytes/_ops.py
+++ b/bitsandbytes/_ops.py
@@ -352,7 +352,7 @@ if ipex_cpu or ipex_xpu:
 
 torch.library.define(
     "bitsandbytes::optimizer_update_32bit",
-    "(str optimizer_name, Tensor(a0!) g, Tensor(a1!) p, Tensor(a2!) state1, Tensor(a3!)? state2, Tensor(a4!)? unorm_vec, float max_unorm, float param_norm, float beta1, float beta2, float beta3, float alpha, float eps, float weight_decay, int step, float lr, float gnorm_scale, bool skip_zeros=False) -> ()",
+    "(str optimizer_name, Tensor(a0!) g, Tensor(a1!) p, Tensor(a2!) state1, Tensor(a3!)? state2, Tensor(a4!)? unorm_vec, float max_unorm, float param_norm, float beta1, float beta2, float beta3, float alpha, float eps, int step, float lr, float weight_decay, float gnorm_scale, bool skip_zeros=False) -> ()",
 )
 
 
@@ -371,9 +371,9 @@ def _(
     beta3: float,
     alpha: float,
     eps: float,
-    weight_decay: float,
     step: int,
     lr: float,
+    weight_decay: float,
     gnorm_scale: float,
     skip_zeros=False,
 ) -> None:

--- a/bitsandbytes/backends/triton/kernels_optim.py
+++ b/bitsandbytes/backends/triton/kernels_optim.py
@@ -1,0 +1,594 @@
+import math
+from typing import Optional
+
+import torch
+
+import triton
+import triton.language as tl
+# from triton.language.extra import libdevice
+
+###########################################
+# Pure torch implementation for reference #
+###########################################
+
+@torch.compile
+def optimizer_update_32bit_impl_torch(
+    optimizer_name: str,
+    g: torch.Tensor,
+    p: torch.Tensor,
+    state1: torch.Tensor,
+    state2: Optional[torch.Tensor],
+    unorm_vec: Optional[torch.Tensor],
+    max_unorm: float,
+    param_norm: float,
+    beta1: float,
+    beta2: float,
+    beta3: float,
+    alpha: float,
+    eps: float,
+    step: int,
+    lr: float,
+    weight_decay: float = 0.0,
+    gnorm_scale: float = 1.0,
+    skip_zeros=False,
+) -> None:
+    """
+    Torch实现的32位优化器，用于性能对比
+    """
+    if skip_zeros:
+        raise NotImplementedError("skip_zeros is not supported on XPU yet")
+
+    # 应用梯度缩放
+    g_scaled = gnorm_scale * g
+    
+    update_scale = 1.0
+
+    # 根据优化器类型进行参数更新
+    if optimizer_name == "adam":
+        # 更新状态
+        state1.mul_(beta1).add_(g_scaled, alpha=1.0 - beta1)
+        state2.mul_(beta2).addcmul_(g_scaled, g_scaled, value=1.0 - beta2)
+        
+        # 计算修正因子
+        correction1 = 1.0 - beta1 ** step
+        correction2_sqrt = math.sqrt(1.0 - beta2 ** step)
+        
+        # 计算 unorm
+        if max_unorm > 0.0 and unorm_vec is not None:
+            # AdamW: unorm is computed from corrected first moment, but before weight decay
+            # See https://github.com/NVIDIA/apex/blob/22603ab6109e346438b8bc439427f8791055b416/apex/optimizers/fused_adam.py#L265
+            s1_corrected = state1 / correction1
+            update_vals = s1_corrected / (torch.sqrt(state2) + eps)
+            update_norm = torch.sum(update_vals * update_vals)
+            unorm_vec.fill_(update_norm)
+            current_unorm = torch.sqrt(update_norm)
+            if current_unorm > max_unorm * param_norm:
+                update_scale = (max_unorm * param_norm) / current_unorm
+
+        # 应用权重衰减 (decoupled weight decay)
+        if weight_decay > 0.0:
+            p.mul_(1.0 - lr * weight_decay)
+        
+        # 更新参数
+        step_size = -lr * correction2_sqrt / correction1
+        update_val = state1 / (torch.sqrt(state2) + eps * correction2_sqrt)
+        p.add_(update_val, alpha=update_scale * step_size)
+        
+    elif optimizer_name == "ademamix":
+        s1_vals = state1[0]
+        s3_vals = state1[1]
+        
+        # 更新状态
+        s1_vals.mul_(beta1).add_(g_scaled, alpha=1.0 - beta1)
+        s3_vals.mul_(beta3).add_(g_scaled, alpha=1.0 - beta3)
+        state2.mul_(beta2).addcmul_(g_scaled, g_scaled, value=1.0 - beta2)
+        
+        # 计算修正因子
+        correction1 = 1.0 - beta1 ** step
+        correction2_sqrt = math.sqrt(1.0 - beta2 ** step)
+        
+        # 计算更新值
+        numerator = (s1_vals / correction1) + (alpha * s3_vals)
+        denominator = (torch.sqrt(state2) / correction2_sqrt) + eps
+        update_vals = numerator / denominator
+
+        if max_unorm > 0.0 and unorm_vec is not None:
+            update_norm = torch.sum(update_vals * update_vals)
+            unorm_vec.fill_(update_norm)
+            current_unorm = torch.sqrt(update_norm)
+            if current_unorm > max_unorm * param_norm:
+                update_scale = (max_unorm * param_norm) / current_unorm
+
+        # 应用权重衰减
+        if weight_decay > 0.0:
+            p.mul_(1.0 - lr * weight_decay)
+        
+        # 更新参数
+        p.add_(update_vals, alpha=-lr * update_scale)
+        
+    elif optimizer_name in ["momentum", "rmsprop", "adagrad", "lion"]:
+        # 这些优化器的 weight_decay 是耦合的
+        g_with_decay = g_scaled
+        if weight_decay > 0.0:
+            g_with_decay = g_with_decay.add(p, alpha=weight_decay)
+
+        if optimizer_name == "momentum":
+            state1.mul_(beta1).add_(g_with_decay)
+            update_vals = state1
+        elif optimizer_name == "rmsprop":
+            state1.mul_(beta1).addcmul_(g_with_decay, g_with_decay, value=1.0 - beta1)
+            update_vals = g_with_decay / (torch.sqrt(state1) + eps)
+        elif optimizer_name == "adagrad":
+            state1.addcmul_(g_with_decay, g_with_decay, value=1.0)
+            update_vals = g_with_decay / (torch.sqrt(state1) + eps)
+        elif optimizer_name == "lion":
+            # Lion 更新: c = sign(beta1 * m + (1-beta1) * g)
+            # p = p - lr * c
+            # m = beta2 * m + (1-beta2) * g
+            momentum_update = state1.mul(beta1).add(g_with_decay, alpha=1.0 - beta1)
+            update_vals = torch.sign(momentum_update)
+            state1.mul_(beta2).add_(g_with_decay, alpha=1.0 - beta2)
+
+        # 计算 unorm
+        if max_unorm > 0.0 and unorm_vec is not None:
+            # 对于Lion, unorm是基于更新后的动量计算的
+            unorm_calc_source = state1 if optimizer_name == "lion" else update_vals
+            update_norm = torch.sum(unorm_calc_source * unorm_calc_source)
+            unorm_vec.fill_(update_norm)
+            current_unorm = torch.sqrt(update_norm)
+            if current_unorm > max_unorm * param_norm:
+                update_scale = (max_unorm * param_norm) / current_unorm
+        
+        # 更新参数
+        if optimizer_name == "lion":
+            p.add_(update_vals, alpha=-lr * update_scale)
+        else:
+            p.add_(update_vals, alpha=-lr * update_scale)
+
+    else:
+        raise ValueError(f"Unsupported optimizer: {optimizer_name}")
+
+#########################
+# Triton implementation #
+#########################
+
+MOMENTUM = 0
+RMSPROP = 1
+ADAGRAD = 2
+ADAM = 3
+# LION should be larger than MOMENTUM, RMSPROP, ADAGRAD due to comparison in kernels
+LION = 4
+ADEMAMIX = 5
+
+name2optimizer_id = {
+    "momentum": MOMENTUM,
+    "rmsprop": RMSPROP,
+    "adagrad": ADAGRAD,
+    "adam": ADAM,
+    "lion": LION,
+    "ademamix": ADEMAMIX,
+}
+
+
+@triton.jit
+def _optimizer_precondition_2state_32bit(
+    g_ptr,
+    p_ptr,
+    state1_ptr,
+    state2_ptr,
+    unorm_ptr,
+    beta1: tl.constexpr,
+    beta2: tl.constexpr,
+    eps: tl.constexpr,
+    weight_decay: tl.constexpr,
+    step,
+    beta1_step,
+    beta2_step,
+    lr,
+    gnorm_scale: tl.constexpr,
+    n_elements,
+    OPTIMIZER_ID: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    N_PER_TH: tl.constexpr,
+):
+    """预处理优化器，计算更新范数（2状态优化器）"""
+    pid = tl.program_id(axis=0)
+    block_start_idx = pid * N_PER_TH
+    offsets = block_start_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE * N_PER_TH)
+    mask = offsets < n_elements
+    
+    # 加载梯度和状态
+    g_vals = tl.load(g_ptr + offsets, mask=mask, other=0.0)
+    s1_vals = tl.load(state1_ptr + offsets, mask=mask, other=0.0)
+    s2_vals = tl.load(state2_ptr + offsets, mask=mask, other=0.0)
+    
+    # 应用梯度缩放
+    g_vals = gnorm_scale * g_vals
+    
+    # 计算修正因子
+    correction1 = 1.0 / (1.0 - beta1_step)
+    correction2 = 1.0 / (1.0 - beta2_step)
+    
+    # 根据优化器类型更新状态
+    if OPTIMIZER_ID == 3: # ADAM
+        # 更新动量
+        s1_vals = s1_vals * beta1 + (1.0 - beta1) * g_vals
+        s2_vals = s2_vals * beta2 + (1.0 - beta2) * g_vals * g_vals
+        
+        # 应用修正
+        s1_vals = s1_vals * correction1
+        s2_vals = s2_vals * correction2
+        
+        # 计算更新值
+        update_vals = s1_vals / (tl.sqrt(s2_vals) + eps)
+        # 计算更新范数
+        update_norm = update_vals * update_vals
+
+    elif OPTIMIZER_ID == 5: # ADEMAMIX
+        update_norm = s1_vals
+
+    # 累加更新范数
+    total_norm = tl.sum(tl.where(mask, update_norm, 0.0))
+    
+    # 原子加到全局范数
+    tl.atomic_add(unorm_ptr, total_norm)
+
+
+@triton.jit
+def _optimizer_precondition_1state_32bit(
+    g_ptr,
+    p_ptr,
+    state1_ptr,
+    state2_ptr,
+    unorm_ptr,
+    beta1: tl.constexpr,
+    beta2: tl.constexpr,
+    eps: tl.constexpr,
+    weight_decay,
+    step, 
+    beta1_step,
+    beta2_step,
+    lr,
+    gnorm_scale: tl.constexpr,
+    n_elements,
+    OPTIMIZER_ID: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    N_PER_TH: tl.constexpr,
+):
+    """预处理优化器，计算更新范数（1状态优化器）"""
+    pid = tl.program_id(axis=0)
+    block_start_idx = pid * N_PER_TH
+    offsets = block_start_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE * N_PER_TH)
+    mask = offsets < n_elements
+    
+    # 加载梯度和状态
+    g_vals = tl.load(g_ptr + offsets, mask=mask, other=0.0)
+    s1_vals = tl.load(state1_ptr + offsets, mask=mask, other=0.0)
+    
+    # 应用梯度缩放
+    g_vals = gnorm_scale * g_vals
+    
+    if OPTIMIZER_ID == 0:  # MOMENTUM
+        # 更新动量
+        if step == 1:
+            s1_vals = g_vals
+        else:
+            s1_vals = s1_vals * beta1 + g_vals
+        update_norm = s1_vals * s1_vals
+
+    elif OPTIMIZER_ID == 4:  # LION
+        # LION 只更新状态，不计算范数
+        s1_vals = s1_vals * beta2 + (1.0 - beta2) * g_vals
+        # update_norm = tl.zeros_like(g_vals)
+        update_norm = s1_vals
+
+    elif OPTIMIZER_ID == 1:  # RMSPROP
+        # 更新RMS状态
+        s1_vals = s1_vals * beta1 + (1.0 - beta1) * g_vals * g_vals
+        update_vals = g_vals / (tl.sqrt(s1_vals) + eps)
+        update_norm = update_vals * update_vals
+
+    elif OPTIMIZER_ID == 2:  # ADAGRAD
+        # 更新累积梯度平方
+        s1_vals = s1_vals + g_vals * g_vals
+        update_vals = g_vals / (tl.sqrt(s1_vals) + eps)
+        update_norm = update_vals * update_vals
+    
+    # 累加更新范数
+    total_norm = tl.sum(tl.where(mask, update_norm, 0.0))
+    
+    # 原子加到全局范数
+    tl.atomic_add(unorm_ptr, total_norm)
+
+
+@triton.jit
+def _optimizer_update_2state_32bit_triton_kernel(
+    g_ptr,
+    p_ptr,
+    state1_ptr,
+    state2_ptr,
+    unorm_ptr,
+    max_unorm: tl.constexpr,
+    param_norm,
+    beta1: tl.constexpr,
+    beta2: tl.constexpr,
+    beta3,
+    alpha,
+    eps: tl.constexpr,
+    weight_decay: tl.constexpr,
+    step, 
+    beta1_step,
+    beta2_step,
+    lr,
+    gnorm_scale: tl.constexpr,
+    skip_zeros,
+    n_elements,
+    OPTIMIZER_ID: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    N_PER_TH: tl.constexpr,
+):
+    """2状态优化器内核"""
+    pid = tl.program_id(axis=0)
+    block_start_idx = pid * N_PER_TH
+    offsets = block_start_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE * N_PER_TH)
+    mask = offsets < n_elements
+    
+    # 加载数据
+    g_vals = tl.load(g_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    p_vals = tl.load(p_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    s1_vals = tl.load(state1_ptr + offsets, mask=mask, other=0.0)
+    s2_vals = tl.load(state2_ptr + offsets, mask=mask, other=0.0)
+    
+    # 对于ADEMAMIX，需要加载额外的状态
+    if OPTIMIZER_ID == 5:  # ADEMAMIX
+        s3_vals = tl.load(state1_ptr + n_elements + offsets, mask=mask, other=0.0)
+    
+    # 应用梯度缩放
+    g_vals = gnorm_scale * g_vals
+    
+    # 计算更新缩放因子
+    update_scale = 1.0
+    if max_unorm > 0.0:
+        current_unorm = tl.sqrt(tl.load(unorm_ptr))
+        if current_unorm > max_unorm * param_norm:
+            update_scale = (max_unorm * param_norm) / current_unorm
+    
+    # 根据优化器类型进行更新
+    if OPTIMIZER_ID == 3:  # ADAM
+        # 更新状态
+        s1_vals = s1_vals * beta1 + (1.0 - beta1) * g_vals
+        s2_vals = s2_vals * beta2 + (1.0 - beta2) * g_vals * g_vals
+
+        # 计算修正因子
+        correction1 = 1.0 - beta1_step
+        correction2 = tl.sqrt(1.0 - beta2_step)
+        step_size = -lr * correction2 / correction1
+
+        # 应用权重衰减
+        if weight_decay > 0.0:
+            p_vals = p_vals * (1.0 - lr * weight_decay)
+
+        # 更新参数
+        update_val = update_scale * step_size * (s1_vals / (tl.sqrt(s2_vals) + eps * correction2))
+        p_vals = p_vals + update_val
+    
+    elif OPTIMIZER_ID == 5:  # ADEMAMIX     
+        # 更新状态
+        s1_vals = s1_vals * beta1 + (1.0 - beta1) * g_vals  # m1
+        s3_vals = s3_vals * beta3 + (1.0 - beta3) * g_vals  # m2
+        s2_vals = s2_vals * beta2 + (1.0 - beta2) * g_vals * g_vals  # nu
+
+        # 计算修正因子
+        correction1 = 1.0 - beta1_step
+        correction2 = tl.sqrt(1.0 - beta2_step)
+
+        # 应用权重衰减
+        if weight_decay > 0.0:
+            p_vals = p_vals * (1.0 - lr * weight_decay)
+        
+        # 更新参数
+        numerator = (s1_vals / correction1) + (alpha * s3_vals)
+        denominator = (tl.sqrt(s2_vals) / correction2) + eps
+        p_vals = p_vals - lr * (numerator / denominator)
+    
+    # 存储更新后的值
+    tl.store(p_ptr + offsets, p_vals, mask=mask)
+    tl.store(state1_ptr + offsets, s1_vals, mask=mask)
+    tl.store(state2_ptr + offsets, s2_vals, mask=mask)
+    
+    # 对于ADEMAMIX，存储额外状态
+    if OPTIMIZER_ID == 5:  # ADEMAMIX
+        tl.store(state1_ptr + n_elements + offsets, s3_vals, mask=mask)
+
+
+@triton.jit
+def _optimizer_update_1state_32bit_triton_kernel(
+    g_ptr,
+    p_ptr, 
+    state1_ptr,
+    state2_ptr,
+    unorm_ptr,
+    max_unorm: tl.constexpr,
+    param_norm,
+    beta1: tl.constexpr,
+    beta2: tl.constexpr,
+    beta3,
+    alpha,
+    eps: tl.constexpr,
+    weight_decay: tl.constexpr,
+    step,
+    beta1_step,
+    beta2_step,
+    lr,
+    gnorm_scale: tl.constexpr,
+    skip_zeros,
+    n_elements,
+    OPTIMIZER_ID: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    N_PER_TH: tl.constexpr,
+):
+    """1状态优化器内核"""
+    pid = tl.program_id(axis=0)
+    block_start_idx = pid * N_PER_TH
+    offsets = block_start_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE * N_PER_TH)
+    mask = offsets < n_elements
+    
+    # 加载数据
+    g_vals = tl.load(g_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    p_vals = tl.load(p_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    s1_vals = tl.load(state1_ptr + offsets, mask=mask, other=0.0)
+
+    # 应用梯度缩放和权重衰减
+    g_vals = gnorm_scale * g_vals
+    if weight_decay > 0.0:
+        g_vals = g_vals + p_vals * weight_decay
+    
+    # 计算更新缩放因子
+    update_scale = 1.0
+    if max_unorm > 0.0:
+        current_unorm = tl.sqrt(tl.load(unorm_ptr))
+        if current_unorm > max_unorm * param_norm + eps:
+            update_scale = (max_unorm * param_norm + eps) / current_unorm
+    
+    # 根据优化器类型进行更新
+    if OPTIMIZER_ID == 0:  # MOMENTUM
+        # 更新动量
+        if step == 1:
+            s1_vals = g_vals
+        else:
+            s1_vals = s1_vals * beta1 + g_vals
+        
+        # 更新参数
+        update_val = update_scale * (-lr * s1_vals)
+        p_vals = p_vals + update_val
+
+    elif OPTIMIZER_ID == 4:  # LION
+        # LION 优化器
+        momentum_update = s1_vals * beta1 + (1.0 - beta1) * g_vals
+        update_val = update_scale * lr * tl.where(momentum_update > 0, 1.0, tl.where(momentum_update < 0, -1.0, 0.0))
+        p_vals = p_vals - update_val
+        
+        # 更新动量状态
+        s1_vals = s1_vals * beta2 + (1.0 - beta2) * g_vals
+
+    elif OPTIMIZER_ID == 1:  # RMSPROP
+        # 更新RMS状态
+        s1_vals = s1_vals * beta1 + (1.0 - beta1) * g_vals * g_vals
+        
+        # 更新参数
+        update_val = update_scale * lr * g_vals / (tl.sqrt(s1_vals) + eps)
+        p_vals = p_vals - update_val
+
+    elif OPTIMIZER_ID == 2:  # ADAGRAD
+        # 更新累积梯度平方
+        s1_vals = s1_vals + g_vals * g_vals
+        
+        # 更新参数
+        update_val = lr * g_vals / (tl.sqrt(s1_vals) + eps)
+        p_vals = p_vals - update_val
+    
+    # 存储更新后的值
+    tl.store(p_ptr + offsets, p_vals, mask=mask)
+    tl.store(state1_ptr + offsets, s1_vals, mask=mask)
+
+
+name2optimizer_32bit_fn = {
+    "adam": {
+        "preprocess": _optimizer_precondition_2state_32bit,
+        "update": _optimizer_update_2state_32bit_triton_kernel,
+    },
+    "ademamix": {
+        "preprocess": _optimizer_precondition_2state_32bit,
+        "update": _optimizer_update_2state_32bit_triton_kernel,
+    },
+    "momentum": {
+        "preprocess": _optimizer_precondition_1state_32bit,
+        "update": _optimizer_update_1state_32bit_triton_kernel,
+    },
+    "rmsprop": {
+        "preprocess": _optimizer_precondition_1state_32bit,
+        "update": _optimizer_update_1state_32bit_triton_kernel,
+    },
+    "adagrad": {
+        "preprocess": _optimizer_precondition_1state_32bit,
+        "update": _optimizer_update_1state_32bit_triton_kernel,
+    },
+    "lion": {
+        "preprocess": _optimizer_precondition_1state_32bit,
+        "update": _optimizer_update_1state_32bit_triton_kernel,
+    },
+}
+
+
+def optimizer_update_32bit_impl(
+    optimizer_name: str,
+    g: torch.Tensor,
+    p: torch.Tensor,
+    state1: torch.Tensor,
+    state2: Optional[torch.Tensor],
+    unorm_vec: Optional[torch.Tensor],
+    max_unorm: float,
+    param_norm: float,
+    beta1: float,
+    beta2: float,
+    beta3: float,
+    alpha: float,
+    eps: float,
+    step: int,
+    lr: float,
+    weight_decay: float = 0.0,
+    gnorm_scale: float = 1.0,
+    skip_zeros=False,
+) -> None:
+    """
+    Triton实现的32位优化器
+    """
+    if skip_zeros:
+        raise NotImplementedError("skip_zeros is not supported on XPU yet")
+
+    BLOCK_SIZE = 256
+    N_PER_TH = 1  # Number of blocks processed per thread.
+    grid = (triton.cdiv(p.numel(), BLOCK_SIZE * N_PER_TH),)
+    optimizer_id = name2optimizer_id[optimizer_name]
+    fn_preprocess = name2optimizer_32bit_fn[optimizer_name]["preprocess"]
+    fn_update = name2optimizer_32bit_fn[optimizer_name]["update"]
+
+    # In torch=2.7 on XPU there is an issue with libdevice.pow, leading to an error.
+    # For backwards compatibility we precompute the bias correction factors.
+    beta1_step = beta1**step
+    beta2_step = beta2**step
+
+    # lion特殊处理
+    if optimizer_name == "lion":
+        fn_update[grid](
+            g, p, state1, state2, unorm_vec, max_unorm, param_norm,
+            beta1, beta2, beta3, alpha, eps, weight_decay, step,
+            beta1_step, beta2_step, lr, gnorm_scale, skip_zeros,
+            p.numel(), optimizer_id, BLOCK_SIZE, N_PER_TH, num_warps=2,
+        )
+
+        if max_unorm > 0.0:
+            unorm_vec.zero_()
+            fn_preprocess[grid](
+                g, p, state1, state2, unorm_vec,
+                beta1, beta2, eps, weight_decay, step, 
+                beta1_step, beta2_step, lr, gnorm_scale,
+                p.numel(), optimizer_id, BLOCK_SIZE, N_PER_TH, num_warps=2,
+            )
+
+    else:
+        if max_unorm > 0.0:
+            unorm_vec.zero_()
+            fn_preprocess[grid](
+                g, p, state1, state2, unorm_vec,
+                beta1, beta2, eps, weight_decay, step, 
+                beta1_step, beta2_step, lr, gnorm_scale,
+                p.numel(), optimizer_id, BLOCK_SIZE, N_PER_TH, num_warps=2,
+            )
+
+        fn_update[grid](
+            g, p, state1, state2, unorm_vec, max_unorm, param_norm,
+            beta1, beta2, beta3, alpha, eps, weight_decay, step,
+            beta1_step, beta2_step, lr, gnorm_scale, skip_zeros,
+            p.numel(), optimizer_id, BLOCK_SIZE, N_PER_TH, num_warps=2,
+        )

--- a/bitsandbytes/backends/xpu/ops.py
+++ b/bitsandbytes/backends/xpu/ops.py
@@ -63,5 +63,6 @@ elif triton_available:
     register_kernel("bitsandbytes::dequantize_4bit.out", "xpu")(triton_ops.dequantize_4bit_inplace)
     register_kernel("bitsandbytes::dequantize_4bit", "xpu")(triton_ops.dequantize_4bit)
     register_kernel("bitsandbytes::gemv_4bit", "xpu")(triton_ops.gemv_4bit)
+    register_kernel("bitsandbytes::optimizer_update_32bit", "xpu")(triton_ops.optimizer_update_32bit)
 else:
     warnings.warn("XPU available but no ipex or triton packages found.")

--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -1199,9 +1199,9 @@ def optimizer_update_32bit(
         beta3,
         alpha,
         eps,
-        weight_decay,
         step,
         lr,
+        weight_decay,
         gnorm_scale,
         skip_zeros,
     )

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -175,6 +175,9 @@ def test_optimizer32bit(dim1, dim2, gtype, optim_name, device):
     if optim_name.startswith("paged_") and sys.platform == "win32":
         pytest.skip("Paged optimizers can have issues on Windows.")
 
+    if optim_name.startswith("paged_") and device == "xpu":
+        pytest.skip("Paged optimizers are not supported on XPU currently.")
+
     if gtype == torch.bfloat16 and optim_name in ["momentum", "rmsprop"]:
         pytest.skip()
     if dim1 == 1 and dim2 == 1:


### PR DESCRIPTION
Based on [#1692](https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1692).

Implemented **32bit optimizers** in triton to use of XPU devices.

The PR includes two implementations:

1. Pure **Torch** implementation: utilizing torch.compile
2. Pure **Triton** implementation: utilizing triton.jit

For the benchmarking on `4096*4096` shapes, the results are as follows:

Pure **Torch** implementation:
```
Torch step (eager): 1.048ms
BNB step: 0.529ms
Torch step (eager): 1.038ms
BNB step: 0.531ms
Torch step (eager): 1.045ms
BNB step: 0.536ms
Torch step (eager): 1.036ms
BNB step: 0.555ms
Torch step (eager): 1.049ms
BNB step: 0.526ms
```
Pure **Triton** implementation: 
```
Torch step (eager): 1.034ms
BNB step: 0.524ms
Torch step (eager): 1.054ms
BNB step: 0.488ms
Torch step (eager): 1.031ms
BNB step: 0.526ms
Torch step (eager): 1.047ms
BNB step: 0.538ms
Torch step (eager): 1.045ms
BNB step: 0.489ms
```
For the benchmarking on `1024*1024` shapes, the results are as follows:
Pure **Torch** implementation:
```
Torch step (eager): 0.339ms
BNB step: 0.219ms
Torch step (eager): 0.339ms
BNB step: 0.231ms
Torch step (eager): 0.345ms
BNB step: 0.228ms
Torch step (eager): 0.325ms
BNB step: 0.224ms
Torch step (eager): 0.327ms
BNB step: 0.224ms
```
Pure **Triton** implementation: 
```
Torch step (eager): 0.346ms
BNB step: 0.226ms
Torch step (eager): 0.337ms
BNB step: 0.216ms
Torch step (eager): 0.338ms
BNB step: 0.215ms
Torch step (eager): 0.333ms
BNB step: 0.226ms
Torch step (eager): 0.349ms
BNB step: 0.235ms
```

The test platform is Intel(R) Data Center GPU Max 1550. Test script reference [#1692](https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1692). **Torch(eager)** is 32bit optimizer from torch, **BNB** is 32bit optimizer.

Considering that the performance gap between **torch.compile** and **Triton** implementations is not significant, and [#1692](https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1692) was implemented with **Triton**, this PR adopts the **Triton** version for submission.

**Note**:Currently, XPU does not support the allocation of memory buffers using a paging mechanism. Therefore, these tests are skipped in ```tests/test_optim.py::test_optimizer32bit```. This functionality will be developed in the future to support full optimizer capabilities.