### PR TITLE
Add Volta support in cu128/cu129 builds

### DIFF
--- a/.github/scripts/build-cuda.sh
+++ b/.github/scripts/build-cuda.sh
@@ -15,10 +15,10 @@ elif [ "${build_arch}" = "aarch64" ]; then
     [[ "${cuda_version}" == 12.8.* || "${cuda_version}" == 12.9.* ]] && build_capability="75;80;90;100;120"
 else
     # By default, target Maxwell through Hopper.
-    build_capability="50;52;60;61;70;75;80;86;89;90"
+    build_capability="50;60;70;75;80;86;89;90"
 
-    # CUDA 12.8+: Add sm100 and sm120; remove < sm75 to align with PyTorch 2.7+cu128 minimum
-    [[ "${cuda_version}" == 12.8.* || "${cuda_version}" == 12.9.* ]] && build_capability="75;80;86;89;90;100;120"
+    # CUDA 12.8+: Add sm100 and sm120; remove < sm70 to align with PyTorch 2.8+cu128 minimum
+    [[ "${cuda_version}" == 12.8.* || "${cuda_version}" == 12.9.* ]] && build_capability="70;75;80;86;89;90;100;120"
 fi
 
 [[ "${build_os}" = windows-* ]] && python3 -m pip install ninja


### PR DESCRIPTION
Following PyTorch's plans for 2.8.0, we'll add back support for Volta GPUs (sm70) in our CUDA 12.8/12.9 builds. 

To compensate for growing wheel size, sm52 and sm61 specific targets are removed, but these devices will still be supported by the sm50 and sm60 targets respectively. However, in the near future we'll likely drop Maxwell support entirely and sm50 can then be removed as well.