### PR TITLE
add py.typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ test = [
 ]
 
 [tool.setuptools]
-package-data = { "*" = ["libbitsandbytes*.*"] }
+package-data = { "*" = ["libbitsandbytes*.*", "py.typed"] }
 
 [tool.setuptools.packages.find]
 include = ["bitsandbytes*"]


### PR DESCRIPTION
py.typed is used to indicate that bnb has typing.