### PR TITLE
for intel xpu case, use MatMul8bitFp even not use ipex

### DIFF
--- a/bitsandbytes/autograd/_functions.py
+++ b/bitsandbytes/autograd/_functions.py
@@ -8,7 +8,7 @@ import torch
 from typing_extensions import deprecated
 
 import bitsandbytes.functional as F
-from bitsandbytes.functional import ipex_cpu, ipex_xpu
+from bitsandbytes.functional import ipex_cpu
 
 # The inverse transformation for the colTuring and colAmpere format were contributed by Alex Borzunov:
 # https://github.com/bigscience-workshop/petals/blob/main/src/petals/utils/linear8bitlt_patch.py


### PR DESCRIPTION
For Intel XPU case, use `MatMul8bitFp` is faster than `MatMul8bitLt`. And it can avoid the datatype overflow issue in [L105](https://github.com/bitsandbytes-foundation/bitsandbytes/blob/main/bitsandbytes/backends/default/ops.py#L105)