### PR TITLE
Add function to reverse 4bit weights for HPU

### DIFF
--- a/bitsandbytes/backends/hpu/ops.py
+++ b/bitsandbytes/backends/hpu/ops.py
@@ -3,11 +3,16 @@ import math
 
 import torch
 
-from bitsandbytes.utils import _reverse_4bit_compress_format
-
 from ..._ops import register_kernel
 from ..utils import GAUDI_SW_VER
 
+# convert btw standard 4-bit compression format and ipex compression format
+# needed for backward compatibility with older versions of gaudi sw
+def _reverse_4bit_compress_format(weight: torch.Tensor):
+    out_1 = (weight & 0xF0) >> 4
+    out_2 = (weight & 0xF) << 4
+    out = out_1 | out_2
+    return out
 
 @register_kernel("bitsandbytes::dequantize_4bit", "hpu")
 def _(

--- a/bitsandbytes/backends/hpu/ops.py
+++ b/bitsandbytes/backends/hpu/ops.py
@@ -6,6 +6,7 @@ import torch
 from ..._ops import register_kernel
 from ..utils import GAUDI_SW_VER
 
+
 # convert btw standard 4-bit compression format and ipex compression format
 # needed for backward compatibility with older versions of gaudi sw
 def _reverse_4bit_compress_format(weight: torch.Tensor):
@@ -13,6 +14,7 @@ def _reverse_4bit_compress_format(weight: torch.Tensor):
     out_2 = (weight & 0xF) << 4
     out = out_1 | out_2
     return out
+
 
 @register_kernel("bitsandbytes::dequantize_4bit", "hpu")
 def _(


### PR DESCRIPTION
Fixes following failure for HPU/Gaudi tests,
ImportError: cannot import name '_reverse_4bit_compress_format' from 'bitsandbytes.utils' (/usr/local/lib/python3.10/dist-packages/bitsandbytes/utils.py) 

Fix is to define this function within backends/hpu/ops.py. This function is needed to maintain backward compatibility with older Gaudi SW releases.