### PR TITLE
Update log

### DIFF
--- a/bitsandbytes/cextension.py
+++ b/bitsandbytes/cextension.py
@@ -294,9 +294,6 @@ def get_native_library() -> BNBNativeLibrary:
     if hasattr(dll, "get_context"):  # only a CUDA-built library exposes this
         return CudaBNBNativeLibrary(dll)
 
-    # TODO: Remove this log for XPU after 8-bit optimizer is supported
-    logger.warning("The 8-bit optimizer is not available on your device, only available on CUDA for now.")
-
     return BNBNativeLibrary(dll)
 
 


### PR DESCRIPTION
XPU supports [8-bit optimizer](https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1692) currently. Therefore, this log needs to be deleted.