### PR TITLE
Build/Package Intel XPU binary for Linux

### DIFF
--- a/.github/scripts/build-xpu.sh
+++ b/.github/scripts/build-xpu.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+declare build_os
+
+set -xeuo pipefail
+
+# We currently only build XPU on Linux.
+if [ "${build_os:0:6}" == ubuntu ]; then
+    # TODO: We might want to pre-build this as our own customized image in the future.
+    image=intel/deep-learning-essentials:2025.1.3-0-devel-ubuntu22.04
+    echo "Using image $image"
+    docker run --rm -i \
+        -w /src -v "$PWD:/src" "$image" sh -c \
+        "apt-get update \
+      && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        cmake bison intel-fw-gpu intel-ocloc \
+      && cmake -DCOMPUTE_BACKEND=xpu . \
+      && cmake --build . --config Release"
+fi
+
+output_dir="output/${build_os}/x86_64"
+mkdir -p "${output_dir}"
+(shopt -s nullglob && cp bitsandbytes/*.{so,dylib,dll} "${output_dir}")

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -104,6 +104,24 @@ jobs:
           path: output/*
           retention-days: 7
 
+  build-shared-libs-xpu:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build C++
+        run: bash .github/scripts/build-xpu.sh
+        env:
+          build_os: ${{ matrix.os }}
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: shared_library_xpu_${{ matrix.os }}
+          path: output/*
+          retention-days: 7
+
   build-shared-libs-rocm:
     strategy:
       matrix:
@@ -153,6 +171,7 @@ jobs:
       - build-shared-libs
       - build-shared-libs-cuda
       - build-shared-libs-rocm
+      - build-shared-libs-xpu
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm, windows-latest, macos-latest]

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: shared_library_xpu_${{ matrix.os }}
+          name: shared_library_xpu_${{ matrix.os }}_x86_64
           path: output/*
           retention-days: 7
 


### PR DESCRIPTION
This PR is introduced in order to add a build/packaging workflow for the SYCL kernels that were introduced in #1679.

The build produces `libbitsandbytes_xpu.so` for the Linux x86-64 platform. However, I have not yet been able to verify that this build works as expected.

As a side note, this build has a minimum glibc >= 2.34 dependency, and we currently tag our wheels as `manylinux_2_24_x86_64`. This requirement is reasonable for XPU, but we want to keep the CUDA support as broad as possible, so I may open a separate followup PR to bundle separate manylinux_2_34 and manylinux_2_24 wheels, with and without XPU support respectively. 

@jiqing-feng @xiaolil1 Please review and let me know if there's any issues with this. Thanks!