### PR TITLE
fix peft cpu ut failure

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -679,6 +679,7 @@ class Int8Params(torch.nn.Parameter):
     def to(self, *args, **kwargs):
         device, dtype, non_blocking, convert_to_format = torch._C._nn._parse_to(*args, **kwargs)
 
+
         if device is not None and device.type != "meta" and self.data.device.type == "cpu":
             if device.type != "cpu" or self.data.dtype != torch.int8:
                 return self._quantize(device)
@@ -690,8 +691,8 @@ class Int8Params(torch.nn.Parameter):
             requires_grad=self.requires_grad,
             has_fp16_weights=self.has_fp16_weights,
         )
-        new_param.CB = self.CB
-        new_param.SCB = self.SCB
+        new_param.CB = self.CB.to(device=device) if self.CB != None else self.CB
+        new_param.SCB = self.SCB.to(device=device) if self.SCB != None else self.SCB
 
         return new_param
 


### PR DESCRIPTION
in `to` only `data` of param moved to the specified device, but `SCB` and `CB` still keep in the before device, this will lead to `peft` below ut fail 
```
pytest -rA tests/test_gpu_examples.py::TestLoftQ::test_bloomz_loftq_8bit[cpu]
```

Since in this code https://github.com/huggingface/peft/blob/main/src/peft/utils/integrations.py#L107, peft will find `weight.data` has different placement from `SCB`, so kind of only partial `to` was done.