### PR TITLE
Update workflow for packaging

### DIFF
--- a/.github/scripts/build-cuda.sh
+++ b/.github/scripts/build-cuda.sh
@@ -33,7 +33,7 @@ if [ "${build_os:0:6}" == ubuntu ]; then
 
     docker run -i -w /src -v "$PWD:/src" "$image" bash -c \
         "dnf -y --refresh update --security \
-        && dnf -y install cmake gcc-toolset-11 --setopt=install_weak_deps=False --setopt=tsflags=nodocs
+        && dnf -y install cmake gcc-toolset-11 --setopt=install_weak_deps=False --setopt=tsflags=nodocs \
         && source scl_source enable gcc-toolset-11 \
         && cmake -DCOMPUTE_BACKEND=cuda -DCOMPUTE_CAPABILITY=\"${build_capability}\" . \
         && cmake --build . --config Release"

--- a/.github/scripts/build-cuda.sh
+++ b/.github/scripts/build-cuda.sh
@@ -32,8 +32,8 @@ if [ "${build_os:0:6}" == ubuntu ]; then
     echo "Using image $image"
 
     docker run -i -w /src -v "$PWD:/src" "$image" bash -c \
-        "dnf update -y \
-        && dnf install cmake gcc-toolset-11 -y \
+        "dnf -y --refresh update --security \
+        && dnf -y install cmake gcc-toolset-11 --setopt=install_weak_deps=False --setopt=tsflags=nodocs
         && source scl_source enable gcc-toolset-11 \
         && cmake -DCOMPUTE_BACKEND=cuda -DCOMPUTE_CAPABILITY=\"${build_capability}\" . \
         && cmake --build . --config Release"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -87,7 +87,7 @@ jobs:
           cuda: ${{ matrix.cuda_version == '13.0.1' && '13.0.0' || matrix.cuda_version }}
           method: "network"
           # The "crt" component is added for CUDA 13.
-          sub-packages: ${{ format('["nvcc"{0},"cudart","cusparse","cublas","thrust","cublas_dev","cusparse_dev"]', startsWith(matrix.cuda_version, '13.') && ',"crt"' || '') }}          sub-packages: '["nvcc","crt","cudart","cusparse","cublas","thrust","cublas_dev","cusparse_dev"]'
+          sub-packages: ${{ format('["nvcc"{0},"cudart","cusparse","cublas","thrust","cublas_dev","cusparse_dev"]', startsWith(matrix.cuda_version, '13.') && ',"crt"' || '') }}
           use-github-cache: false
           use-local-cache: false
           log-file-suffix: ${{matrix.os}}-${{matrix.cuda_version}}.txt

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -87,8 +87,8 @@ jobs:
           cuda: ${{ matrix.cuda_version == '13.0.1' && '13.0.0' || matrix.cuda_version }}
           # TODO: Build fails when using "network" on CUDA 13.
           method: ${{ startsWith(matrix.cuda_version, '13.') && 'local' || 'network' }}
-          # The "crt" component is added for CUDA 13.
-          sub-packages: ${{ format('["nvcc"{0},"cudart","cusparse","cublas","thrust","cublas_dev","cusparse_dev"]', startsWith(matrix.cuda_version, '13.') && ',"crt"' || '') }}
+          # The "crt" "nvvm" and "nvptxcompiler" components are added for CUDA 13.
+          sub-packages: ${{ format('["nvcc"{0},"cudart","cusparse","cublas","thrust","cublas_dev","cusparse_dev"]', startsWith(matrix.cuda_version, '13.') && ',"crt","nvvm","nvptxcompiler"' || '') }}
           use-github-cache: false
           use-local-cache: false
           log-file-suffix: ${{matrix.os}}-${{matrix.cuda_version}}.txt

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -85,8 +85,7 @@ jobs:
         with:
           # Temporary: Use CUDA 13.0.0 for Windows until 13.0.1 is supported with this action.
           cuda: ${{ matrix.cuda_version == '13.0.1' && '13.0.0' || matrix.cuda_version }}
-          # TODO: Build fails when using "network" on CUDA 13.
-          method: ${{ startsWith(matrix.cuda_version, '13.') && 'local' || 'network' }}
+          method: "network"
           # The "crt" "nvvm" and "nvptxcompiler" components are added for CUDA 13.
           sub-packages: ${{ format('["nvcc"{0},"cudart","cusparse","cublas","thrust","cublas_dev","cusparse_dev"]', startsWith(matrix.cuda_version, '13.') && ',"crt","nvvm","nvptxcompiler"' || '') }}
           use-github-cache: false

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -135,8 +135,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Docker multiarch
-        uses: docker/setup-qemu-action@v3
       - name: Clean up disk space
         run: |
           sudo rm -rf \

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -86,7 +86,8 @@ jobs:
           # Temporary: Use CUDA 13.0.0 for Windows until 13.0.1 is supported with this action.
           cuda: ${{ matrix.cuda_version == '13.0.1' && '13.0.0' || matrix.cuda_version }}
           method: "network"
-          sub-packages: '["nvcc","crt","cudart","cusparse","cublas","thrust","cublas_dev","cusparse_dev"]'
+          # The "crt" component is added for CUDA 13.
+          sub-packages: ${{ format('["nvcc"{0},"cudart","cusparse","cublas","thrust","cublas_dev","cusparse_dev"]', startsWith(matrix.cuda_version, '13.') && ',"crt"' || '') }}          sub-packages: '["nvcc","crt","cudart","cusparse","cublas","thrust","cublas_dev","cusparse_dev"]'
           use-github-cache: false
           use-local-cache: false
           log-file-suffix: ${{matrix.os}}-${{matrix.cuda_version}}.txt

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,9 +36,9 @@ jobs:
             arch: x86_64
           - os: ubuntu-22.04-arm
             arch: aarch64
-          - os: windows-latest
+          - os: windows-2025
             arch: x86_64
-          - os: macos-latest
+          - os: macos-15
             arch: arm64
     runs-on: ${{ matrix.os }}
     steps:
@@ -65,13 +65,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-latest]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2025]
         include:
           - os: ubuntu-22.04
             arch: x86_64
           - os: ubuntu-22.04-arm
             arch: aarch64
-          - os: windows-latest
+          - os: windows-2025
             arch: x86_64
         cuda_version:
           ["11.8.0", "12.0.1", "12.1.1", "12.2.2", "12.3.2", "12.4.1", "12.5.1", "12.6.3", "12.8.1", "12.9.1", "13.0.1"]
@@ -177,15 +177,15 @@ jobs:
       - build-xpu
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-latest, macos-latest]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2025, macos-15]
         include:
           - os: ubuntu-22.04
             arch: x86_64
           - os: ubuntu-22.04-arm
             arch: aarch64
-          - os: windows-latest
+          - os: windows-2025
             arch: x86_64
-          - os: macos-latest
+          - os: macos-15
             arch: arm64
         # The specific Python version is irrelevant in this context as we are only packaging non-C extension
         # code. This ensures compatibility across Python versions, as compatibility is

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -85,7 +85,8 @@ jobs:
         with:
           # Temporary: Use CUDA 13.0.0 for Windows until 13.0.1 is supported with this action.
           cuda: ${{ matrix.cuda_version == '13.0.1' && '13.0.0' || matrix.cuda_version }}
-          method: "network"
+          # TODO: Build fails when using "network" on CUDA 13.
+          method: ${{ startsWith(matrix.cuda_version, '13.') && 'local' || 'network' }}
           # The "crt" component is added for CUDA 13.
           sub-packages: ${{ format('["nvcc"{0},"cudart","cusparse","cublas","thrust","cublas_dev","cusparse_dev"]', startsWith(matrix.cuda_version, '13.') && ',"crt"' || '') }}
           use-github-cache: false

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -86,7 +86,7 @@ jobs:
           # Temporary: Use CUDA 13.0.0 for Windows until 13.0.1 is supported with this action.
           cuda: ${{ matrix.cuda_version == '13.0.1' && '13.0.0' || matrix.cuda_version }}
           method: "network"
-          sub-packages: '["nvcc","cudart","cusparse","cublas","thrust","cublas_dev","cusparse_dev"]'
+          sub-packages: '["nvcc","crt","cudart","cusparse","cublas","thrust","cublas_dev","cusparse_dev"]'
           use-github-cache: false
           use-local-cache: false
           log-file-suffix: ${{matrix.os}}-${{matrix.cuda_version}}.txt

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,12 +6,13 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/python-package.yml"
+      - ".github/scripts/**"
       - "bitsandbytes/**"
       - "csrc/**"
       - "include/**"
       - "tests/**"
       - "CMakeLists.txt"
-      - "requirements*.txt"
+      - "MANIFEST.in"
       - "setup.py"
       - "pyproject.toml"
   release:
@@ -25,9 +26,9 @@ concurrency:
 
 jobs:
   ##
-  # This job matrix builds the non-CUDA versions of the libraries for all supported platforms.
+  # This job matrix builds the CPU versions of the libraries for all supported platforms.
   ##
-  build-shared-libs:
+  build-cpu:
     strategy:
       matrix:
         include:
@@ -56,10 +57,11 @@ jobs:
           name: shared_library_${{ matrix.os }}_${{ matrix.arch }}
           path: output/*
           retention-days: 7
+
   ##
   # This job matrix builds the CUDA versions of the libraries for platforms that support CUDA (Linux x64/aarch64 + Windows x64)
   ##
-  build-shared-libs-cuda:
+  build-cuda:
     strategy:
       fail-fast: false
       matrix:
@@ -77,14 +79,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         # Windows: We install Cuda on the agent (slow)
-      #- uses: Jimver/cuda-toolkit@433d453c1fa37d10a3254452fa8e284441c9192d # v0.2.27
       - uses: N-Storm/cuda-toolkit@d68ba29a800229200a2c3f572f9e816d7f67cdb4 # v0.2.24m
         if: startsWith(matrix.os, 'windows')
         id: cuda-toolkit
         with:
           # Temporary: Use CUDA 13.0.0 for Windows until 13.0.1 is supported with this action.
           cuda: ${{ matrix.cuda_version == '13.0.1' && '13.0.0' || matrix.cuda_version }}
-          method: "local"
+          method: "network"
+          sub-packages: '["nvcc","cudart","cusparse","cublas","thrust","cublas_dev","cusparse_dev"]'
           use-github-cache: false
           use-local-cache: false
           log-file-suffix: ${{matrix.os}}-${{matrix.cuda_version}}.txt
@@ -104,7 +106,7 @@ jobs:
           path: output/*
           retention-days: 7
 
-  build-shared-libs-xpu:
+  build-xpu:
     strategy:
       matrix:
         os: [ubuntu-22.04]
@@ -122,7 +124,7 @@ jobs:
           path: output/*
           retention-days: 7
 
-  build-shared-libs-rocm:
+  build-rocm:
     strategy:
       matrix:
         os: [ubuntu-22.04]
@@ -168,10 +170,10 @@ jobs:
 
   build-wheels:
     needs:
-      - build-shared-libs
-      - build-shared-libs-cuda
-      - build-shared-libs-rocm
-      - build-shared-libs-xpu
+      - build-cpu
+      - build-cuda
+      - build-rocm
+      - build-xpu
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm, windows-latest, macos-latest]
@@ -185,7 +187,7 @@ jobs:
           - os: macos-latest
             arch: arm64
         # The specific Python version is irrelevant in this context as we are only packaging non-C extension
-        # code. This ensures compatibility across Python versions, including Python 3.9, as compatibility is
+        # code. This ensures compatibility across Python versions, as compatibility is
         # dictated by the packaged code itself, not the Python version used for packaging.
         python-version: ["3.10"]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
* Run the workflow when files change in `.github/scripts/**`
* Shorter names for build jobs
* Change Windows CUDA install back to "network" using subpackages
* Limit package updates to security only in CUDA build pipeline
* Removes an unnecessary step in the ROCm build workflow