### PR TITLE
ROCm: Add 6.4 and 7.0 builds

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -131,7 +131,7 @@ jobs:
         os: [ubuntu-22.04]
         arch: [x86_64]
         rocm_version:
-          ["6.1.2", "6.2.4", "6.3.2"]
+          ["6.1.2", "6.2.4", "6.3.4", "6.4.4", "7.0"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
* Add builds for ROCm 6.4.4 and 7.0.0 to the build pipeline.
* Update ROCm 6.3.2 build to use 6.3.4.