### PR TITLE
Fix regression in 8bit parameter device movement

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -694,11 +694,10 @@ class Int8Params(torch.nn.Parameter):
         )
 
         # If we had already quantized, move the statistics appropriately.
-        if is_quantized and device is not None:
-            if self.CB is not None:
-                new_param.CB = new_param.data
+        if is_quantized:
+            new_param.CB = new_param.data
 
-            if self.SCB is not None:
+            if self.SCB is not None and device is not None:
                 new_param.SCB = self.SCB.to(device)
 
         return new_param


### PR DESCRIPTION
This PR fixes a regression introduced in #1769. That change, released in v0.48.0, resulted in broken generation for pre-quantized 8bit checkpoints in HF transformers.

Fixes #1775 