### PR TITLE
Fix indexing overflow issue for blockwise quantization

### DIFF
--- a/bitsandbytes/backends/cuda/ops.py
+++ b/bitsandbytes/backends/cuda/ops.py
@@ -326,7 +326,7 @@ def _(
             get_ptr(absmax),
             get_ptr(out),
             ct.c_int32(blocksize),
-            ct.c_int(n),
+            ct.c_int32(n),
         )
 
         if A.dtype == torch.bfloat16:
@@ -403,7 +403,7 @@ def _dequantize_4bit_impl(
             get_ptr(absmax),
             get_ptr(out),
             ct.c_int(blocksize),
-            ct.c_int(out.numel()),
+            ct.c_int32(out.numel()),
             _get_tensor_stream(A),
         )
 


### PR DESCRIPTION
Fixes #1782 

This PR resolves an issue with int32 overflows in indexing calculations used by the blockwise quantization and dequantization kernels. It also adds tests to verify that quantization and dequantization works on tensors with the maximum supported size of `2**31 - 1` elements. Prior to this fix, the quantization kernel would have issues with tensors above `2**30` elements.