### PR TITLE
Fix regression with CPU/disk offloading for accelerate + int8

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -697,7 +697,7 @@ class Int8Params(torch.nn.Parameter):
         if is_quantized:
             new_param.CB = new_param.data
 
-            if self.SCB is not None and device is not None:
+            if device is not None and self.SCB is not None and self.SCB.device.type != "meta":
                 new_param.SCB = self.SCB.to(device)
 
         return new_param


### PR DESCRIPTION
This fixes a regression introduced in v0.48.0 which caused some test failures in Accelerate. The failing tests load an int8 model across multiple devices: CPU, GPUs, and also disk offload.

This issue was only present in an uncommon edge use case.


cc: @SunMarc 