### PR TITLE
CI: Enable tests on Linux x86-64 with CUDA 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,8 +54,7 @@ jobs:
   build-cuda:
     strategy:
       matrix:
-        # TODO: Add 13.0.1 when we have runners with new enough drivers.
-        cuda_version: ["11.8.0", "12.6.3", "12.8.1", "12.9.1"]
+        cuda_version: ["11.8.0", "12.6.3", "12.8.1", "13.0.1"]
         os: [ubuntu-22.04, ubuntu-22.04-arm]
         include:
           - os: ubuntu-22.04
@@ -349,26 +348,20 @@ jobs:
         os: [ubuntu-22.04, windows-2025]
         arch: [x86_64]
         gpu: [T4, L40S]
-        cuda_version: ["11.8.0", "12.6.3", "12.8.1", "12.9.1"] #, "13.0.1"]
+        cuda_version: ["11.8.0", "12.6.3", "12.8.1", "13.0.1"]
         include:
           - cuda_version: "11.8.0"
             torch_version: "2.3.1"
             pypi_index: "https://download.pytorch.org/whl/cu118"
           - cuda_version: "12.6.3"
-            torch_version: "2.6.0"
+            torch_version: "2.7.1"
             pypi_index: "https://download.pytorch.org/whl/cu126"
-          - cuda_version: "12.9.1"
-            torch_version: "2.8.0"
-            pypi_index: "https://download.pytorch.org/whl/cu129"
           - cuda_version: "12.8.1"
-            torch_version: "2.9.0"
-            pypi_index: "https://download.pytorch.org/whl/test/cu128"
-
-          # Note: Currently our runners do not have new enough drivers for CUDA 13.
-          # Add this when supported.
-          # - cuda_version: "13.0.1"
-          #   torch_version: "2.9.0"
-          #   pypi_index: "https://download.pytorch.org/whl/test/cu130"
+            torch_version: "2.8.0"
+            pypi_index: "https://download.pytorch.org/whl/cu128"
+          - cuda_version: "13.0.1"
+            torch_version: "2.9.1"
+            pypi_index: "https://download.pytorch.org/whl/cu130"
 
 
           # Linux L40S runners


### PR DESCRIPTION
As per title. Also test with PyTorch 2.9.1 instead of 2.9.0.