### PR TITLE
ROCm: reduce size of builds

### DIFF
--- a/.github/scripts/build-rocm.sh
+++ b/.github/scripts/build-rocm.sh
@@ -19,7 +19,7 @@ if [ "${build_os:0:6}" == ubuntu ]; then
         -w /src -v "$PWD:/src" "$image" sh -c \
         "apt-get update \
       && pip install cmake==3.31.6 \
-      && cmake -DCOMPUTE_BACKEND=hip -DBNB_ROCM_ARCH=\"${bnb_rocm_arch}\" . \
+      && cmake -DCOMPUTE_BACKEND=hip -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_HIP_FLAGS=\"--offload-compress\" -DBNB_ROCM_ARCH=\"${bnb_rocm_arch}\" . \
       && cmake --build ."
 fi
 


### PR DESCRIPTION
This PR significantly reduces the size of our ROCm library builds with `--offload-compress`. This is important so that we can reduce the bloat it would add when we release wheel packages.

Our current builds with ROCm 6.2 + 6.3 + 6.4 + 7.0 + 7.1 are reduced from ~35MB to ~5MB.