### PR TITLE
ROCm: Add gfx1150/gfx1151 to build targets

### DIFF
--- a/.github/scripts/build-rocm.sh
+++ b/.github/scripts/build-rocm.sh
@@ -6,8 +6,8 @@ declare rocm_version
 set -xeuo pipefail
 bnb_rocm_arch="gfx90a;gfx942;gfx1100;gfx1101"
 
-# ROCm 6.4+ - Add gfx1200/gfx1201. Note we assume >=6.4.1.
-[[ "${rocm_version}" == 6.4.* || "${rocm_version}" == 7.* ]] && bnb_rocm_arch="${bnb_rocm_arch};gfx1200;gfx1201"
+# ROCm 6.4+ - Add gfx1150/gfx1151/gfx1200/gfx1201. Note we assume >=6.4.4.
+[[ "${rocm_version}" == 6.4.* || "${rocm_version}" == 7.* ]] && bnb_rocm_arch="${bnb_rocm_arch};gfx1150;gfx1151;gfx1200;gfx1201"
 
 # ROCm 7.0+ - Add gfx950
 [[ "${rocm_version}" == 7.* ]] && bnb_rocm_arch="${bnb_rocm_arch};gfx950"

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ bitsandbytes has the following minimum requirements for all platforms:
       <td>🟥 AMD GPU <br><code>cuda</code></td>
       <td>
         CDNA: gfx90a, gfx942, gfx950<br>
-        RDNA: gfx1100, gfx1200, gfx1201
+        RDNA: gfx1100, gfx1150, gfx1151, gfx1200, gfx1201
       </td>
       <td>✅</td>
       <td>〰️</td>

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -194,9 +194,9 @@ The currently distributed preview `bitsandbytes` are built with the following co
 |--------------------|----------|---------------------------------------------------------------------|
 | **Linux x86-64**   | 6.2.4    | CDNA: gfx90a, gfx942 / RDNA: gfx1100, gfx1101
 | **Linux x86-64**   | 6.3.4    | CDNA: gfx90a, gfx942 / RDNA: gfx1100, gfx1101
-| **Linux x86-64**   | 6.4.4    | CDNA: gfx90a, gfx942 / RDNA: gfx1100, gfx1101, gfx1200, gfx1201
-| **Linux x86-64**   | 7.0.2    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100 / gfx1101 / gfx1200 / gfx1201
-| **Linux x86-64**   | 7.1.0    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100 / gfx1101 / gfx1200 / gfx1201
+| **Linux x86-64**   | 6.4.4    | CDNA: gfx90a, gfx942 / RDNA: gfx1100, gfx1101, gfx1150, gfx1151, gfx1200, gfx1201
+| **Linux x86-64**   | 7.0.2    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1150, gfx1151, gfx1200, gfx1201
+| **Linux x86-64**   | 7.1.0    | CDNA: gfx90a, gfx942, gfx950 / RDNA:  gfx1100, gfx1101, gfx1150, gfx1151, gfx1200, gfx1201
 
 **Windows is not currently supported.**
 


### PR DESCRIPTION
Resolves #1821