### PR TITLE
Refactor: Use logging module for diagnostics and warnings instead of print statements

### DIFF
--- a/bitsandbytes/__init__.py
+++ b/bitsandbytes/__init__.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import logging
 import importlib
 import sys
 
@@ -19,6 +20,10 @@ from .backends.cpu import ops as cpu_ops
 from .backends.default import ops as default_ops
 from .nn import modules
 from .optim import adam
+
+# Library logging should be opt-in for downstream users.
+# (No handlers are configured by default; CLI entrypoints may configure logging.)
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 # This is a signal for integrations with transformers/diffusers.
 # Eventually we may remove this but it is currently required for compatibility.

--- a/bitsandbytes/diagnostics/cuda.py
+++ b/bitsandbytes/diagnostics/cuda.py
@@ -108,9 +108,10 @@ def find_cudart_libraries() -> Iterator[Path]:
 
 
 def _print_cuda_diagnostics(cuda_specs: CUDASpecs) -> None:
-    print(
-        f"PyTorch settings found: CUDA_VERSION={cuda_specs.cuda_version_string}, "
-        f"Highest Compute Capability: {cuda_specs.highest_compute_capability}.",
+    logger.info(
+        "PyTorch settings found: CUDA_VERSION=%s, Highest Compute Capability: %s.",
+        cuda_specs.cuda_version_string,
+        cuda_specs.highest_compute_capability,
     )
 
     binary_path = get_cuda_bnb_library_path(cuda_specs)
@@ -133,7 +134,7 @@ def _print_cuda_diagnostics(cuda_specs: CUDASpecs) -> None:
 
 
 def _print_hip_diagnostics(cuda_specs: CUDASpecs) -> None:
-    print(f"PyTorch settings found: ROCM_VERSION={cuda_specs.cuda_version_string}")
+    logger.info("PyTorch settings found: ROCM_VERSION=%s", cuda_specs.cuda_version_string)
 
     binary_path = get_cuda_bnb_library_path(cuda_specs)
     if not binary_path.exists():
@@ -165,7 +166,7 @@ def print_diagnostics(cuda_specs: CUDASpecs) -> None:
 def _print_cuda_runtime_diagnostics() -> None:
     cudart_paths = list(find_cudart_libraries())
     if not cudart_paths:
-        print("CUDA SETUP: WARNING! CUDA runtime files not found in any environmental path.")
+        logger.warning("CUDA SETUP: WARNING! CUDA runtime files not found in any environmental path.")
     elif len(cudart_paths) > 1:
         print_dedented(
             f"""
@@ -186,13 +187,13 @@ def _print_cuda_runtime_diagnostics() -> None:
             """,
         )
         for pth in cudart_paths:
-            print(f"* Found CUDA runtime at: {pth}")
+            logger.info("* Found CUDA runtime at: %s", pth)
 
 
 def _print_hip_runtime_diagnostics() -> None:
     cudart_paths = list(find_cudart_libraries())
     if not cudart_paths:
-        print("WARNING! ROCm runtime files not found in any environmental path.")
+        logger.warning("WARNING! ROCm runtime files not found in any environmental path.")
     elif len(cudart_paths) > 1:
         print_dedented(
             f"""
@@ -209,7 +210,7 @@ def _print_hip_runtime_diagnostics() -> None:
         )
 
         for pth in cudart_paths:
-            print(f"* Found ROCm runtime at: {pth}")
+            logger.info("* Found ROCm runtime at: %s", pth)
 
 
 def print_runtime_diagnostics() -> None:

--- a/bitsandbytes/diagnostics/utils.py
+++ b/bitsandbytes/diagnostics/utils.py
@@ -1,12 +1,15 @@
+import logging
 import textwrap
 
 HEADER_WIDTH = 60
 
+logger = logging.getLogger(__name__)
+
 
 def print_header(txt: str, width: int = HEADER_WIDTH, filler: str = "=") -> None:
     txt = f" {txt} " if txt else ""
-    print(txt.center(width, filler))
+    logger.info(txt.center(width, filler))
 
 
 def print_dedented(text):
-    print("\n".join(textwrap.dedent(text).strip().split("\n")))
+    logger.info("\n".join(textwrap.dedent(text).strip().split("\n")))

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import copy
+import logging
 from typing import Any, Optional, TypeVar, Union, overload
 import warnings
 
@@ -22,6 +23,8 @@ from bitsandbytes.optim import GlobalOptimManager
 from bitsandbytes.utils import INVERSE_LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING, OutlierTracer
 
 T = TypeVar("T", bound="torch.nn.Module")
+
+logger = logging.getLogger(__name__)
 
 
 class StableEmbedding(torch.nn.Embedding):
@@ -1115,9 +1118,10 @@ class OutlierAwareLinear(nn.Linear):
         if self.outlier_dim is None:
             tracer = OutlierTracer.get_instance()
             if not tracer.is_initialized():
-                print("Please use OutlierTracer.initialize(model) before using the OutlierAwareLinear layer")
+                logger.warning(
+                    "Please use OutlierTracer.initialize(model) before using the OutlierAwareLinear layer",
+                )
             outlier_idx = tracer.get_outliers(self.weight)
-            # print(outlier_idx, tracer.get_hvalue(self.weight))
             self.outlier_dim = outlier_idx
 
         if not self.is_quantized:

--- a/bitsandbytes/research/autograd/_functions.py
+++ b/bitsandbytes/research/autograd/_functions.py
@@ -234,7 +234,6 @@ class SwitchBackBnb(torch.autograd.Function):
 
         # 2. Quantize B
         if state.has_fp16_weights:
-            # print('B shape', B.shape)
             has_grad = getattr(B, "grad", None) is not None
             is_transposed = not B.is_contiguous() and B.shape[0] == B.stride(1)
             if is_transposed:
@@ -323,8 +322,6 @@ class SwitchBackBnb(torch.autograd.Function):
         _Cgrad, _Cgradt, _SCgrad, _SCgradt, _outlier_cols = F.int8_double_quant(grad_output.to(torch.float16))
 
         if req_gradB:
-            # print('back A shape', A.shape)
-            # print('grad output t shape', grad_output.t().shape)
             grad_B = torch.matmul(grad_output.t(), A)
 
         if req_gradA:

--- a/bitsandbytes/triton/matmul_perf_model.py
+++ b/bitsandbytes/triton/matmul_perf_model.py
@@ -3,6 +3,7 @@
 
 import functools
 import heapq
+import logging
 
 import torch
 
@@ -14,6 +15,8 @@ from triton.testing import (
     get_max_tensorcore_tflops,
     nvsmi,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @functools.lru_cache
@@ -125,10 +128,13 @@ def estimate_matmul_time(
 
     total_time_ms = max(compute_ms, load_ms) + store_ms
     if debug:
-        print(
-            f"Total time: {total_time_ms}ms, compute time: {compute_ms}ms, "
-            f"loading time: {load_ms}ms, store time: {store_ms}ms, "
-            f"Activate CTAs: {active_cta_ratio * 100}%"
+        logger.debug(
+            "Total time: %sms, compute time: %sms, loading time: %sms, store time: %sms, Activate CTAs: %s%%",
+            total_time_ms,
+            compute_ms,
+            load_ms,
+            store_ms,
+            active_cta_ratio * 100,
         )
     return total_time_ms
 

--- a/bitsandbytes/utils.py
+++ b/bitsandbytes/utils.py
@@ -1,8 +1,11 @@
 import json
+import logging
 import shlex
 import subprocess
 
 import torch
+
+logger = logging.getLogger(__name__)
 
 
 def outlier_hook(module, input):
@@ -65,7 +68,7 @@ class OutlierTracer:
 
     def get_outliers(self, weight):
         if not self.is_initialized():
-            print("Outlier tracer is not initialized...")
+            logger.warning("Outlier tracer is not initialized...")
             return None
         hvalue = self.get_hvalue(weight)
         if hvalue in self.hvalue2outlier_idx:


### PR DESCRIPTION
Replace all print() statements with logging calls and add a NullHandler to the top-level logger to allow downstream users to manage and filter library logs.

This change prevents bitsandbytes from writing directly to stdout/stderr from library code paths, making its logging opt-in. The CLI entrypoint (python -m bitsandbytes) now configures logging only for its run, respecting the BNB_LOG_LEVEL environment variable.


With respect to https://github.com/bitsandbytes-foundation/bitsandbytes/issues/919