### PR TITLE
ROCm 7.2 build and doc changes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -136,7 +136,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         arch: [x86_64]
-        rocm_version: ["6.2.4", "6.3.4", "6.4.4", "7.0.2", "7.1"]
+        rocm_version: ["6.2.4", "6.3.4", "6.4.4", "7.0.2", "7.1", "7.2"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -202,7 +202,8 @@ The currently distributed `bitsandbytes` are built with the following configurat
 | **Linux x86-64**   | 6.3.4    | CDNA: gfx90a, gfx942 / RDNA: gfx1100, gfx1101
 | **Linux x86-64**   | 6.4.4    | CDNA: gfx90a, gfx942 / RDNA: gfx1100, gfx1101, gfx1150, gfx1151, gfx1200, gfx1201
 | **Linux x86-64**   | 7.0.2    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1150, gfx1151, gfx1200, gfx1201
-| **Linux x86-64**   | 7.1.0    | CDNA: gfx90a, gfx942, gfx950 / RDNA:  gfx1100, gfx1101, gfx1150, gfx1151, gfx1200, gfx1201
+| **Linux x86-64**   | 7.1.0    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1150, gfx1151, gfx1200, gfx1201
+| **Linux x86-64**   | 7.2.0    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1150, gfx1151, gfx1200, gfx1201
 
 **Windows is not currently supported.**
 
@@ -214,7 +215,7 @@ pip install bitsandbytes
 
 ### Compile from Source[[rocm-compile]]
 
-bitsandbytes can be compiled from ROCm 6.2 - ROCm 7.1.
+bitsandbytes can be compiled from ROCm 6.2 - ROCm 7.2.
 
 To compile from source, you need CMake >= **3.31.6**.
 


### PR DESCRIPTION
Adds workflow changes to support the upcoming ROCm 7.2 release. Reflects this in the installation docs as well.