### PR TITLE
[Docs Update] QLoRA 4-bit Support on ROCm

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ bitsandbytes has the following minimum requirements for all platforms:
         RDNA: gfx1100, gfx1101, gfx1150, gfx1151, gfx1200, gfx1201
       </td>
       <td>✅</td>
-      <td>〰️</td>
+      <td>✅</td>
       <td>✅</td>
     </tr>
     <tr>

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -186,8 +186,7 @@ pip install -e .
 ## AMD ROCm (Preview)[[rocm]]
 
 * Support for AMD GPUs is currently in a preview state.
-* All features are supported for consumer RDNA devices.
-* The Data Center products currently lack support for the default 4bit blocksize of 64, and as such default to 128.
+* All features are supported for both consumer RDNA devices and Data Center CDNA products.
 * A compatible PyTorch version with AMD ROCm support is required. It is recommended to use the latest stable release. See [PyTorch on ROCm](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/pytorch-install.html) for guidance.
 
 ### Installation from PyPI[[rocm-pip]]


### PR DESCRIPTION
Docs update after merging this PR: [https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1856](https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1856),  which enables support for 4-bit quantization with `blocksize=64` on ROCm CDNA devices.

