### PR TITLE
Add LARS to str2optimizer32bit and fix error message

### DIFF
--- a/bitsandbytes/backends/cuda/ops.py
+++ b/bitsandbytes/backends/cuda/ops.py
@@ -574,6 +574,10 @@ str2optimizer32bit = {
         lib.cademamix32bit_grad_fp16,
         lib.cademamix32bit_grad_bf16,
     ),
+    "lars": (
+        lib.cmomentum32bit_grad_32,
+        lib.cmomentum32bit_grad_16,
+    ),
 }
 
 str2optimizer8bit_blockwise = {
@@ -633,7 +637,7 @@ def _optimizer_update_32bit_impl(
     optim_fns = str2optimizer32bit.get(optimizer_name, None)
     if optim_fns is None:
         raise ValueError(
-            f"Unsupported optimizer name: {optimizer_name}. Supported optimizers: {list(str2optimizer8bit_blockwise.keys())}"
+            f"Unsupported optimizer name: {optimizer_name}. Supported optimizers: {list(str2optimizer32bit.keys())}"
         )
     if g.dtype == torch.float32:
         optim_func = optim_fns[0]

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -102,6 +102,11 @@ str2optimizers["momentum8bit_blockwise"] = (
     lambda pxx: bnb.optim.SGD8bit(pxx, 0.01, 0.9, block_wise=True),
 )
 
+str2optimizers["lars"] = (
+    lambda pxx: bnb.optim.PytorchLARS(pxx, 0.01, 0.9),
+    lambda pxx: bnb.optim.LARS(pxx, 0.01, 0.9),
+)
+
 str2optimizers["rmsprop"] = (
     lambda pxx: torch.optim.RMSprop(pxx, 0.01, 0.9),
     lambda pxx: bnb.optim.RMSprop(pxx, 0.01, 0.9, block_wise=False),
@@ -118,6 +123,7 @@ str2statenames["paged_adam"] = [("exp_avg", "state1"), ("exp_avg_sq", "state2")]
 str2statenames["lion"] = [("exp_avg", "state1")]
 str2statenames["paged_lion"] = [("exp_avg", "state1")]
 str2statenames["momentum"] = [("momentum_buffer", "state1")]
+str2statenames["lars"] = [("momentum_buffer", "state1")]
 str2statenames["lamb"] = [("exp_avg", "state1"), ("exp_avg_sq", "state2")]
 str2statenames["rmsprop"] = [("square_avg", "state1")]
 
@@ -155,6 +161,7 @@ optimizer_names_32bit = [
     "paged_adamw",
     "paged_adam",
     "momentum",
+    "lars",
     "rmsprop",
     "lion",
     "paged_lion",
@@ -181,7 +188,7 @@ def test_optimizer32bit(dim1, dim2, gtype, optim_name, device):
     if optim_name.startswith("paged_") and device == "xpu":
         pytest.skip("Paged optimizers are not supported on XPU currently.")
 
-    if gtype == torch.bfloat16 and optim_name in ["momentum", "rmsprop"]:
+    if gtype == torch.bfloat16 and optim_name in ["momentum", "lars", "rmsprop"]:
         pytest.skip()
     if dim1 == 1 and dim2 == 1:
         return


### PR DESCRIPTION
## Summary
- Add `"lars"` entry to `str2optimizer32bit` dictionary, mapping to momentum kernels (`cmomentum32bit_grad_32`, `cmomentum32bit_grad_16`). This follows the same pattern as LAMB→adam kernels (fixed in #1118).
- Fix incorrect error message in `_optimizer_update_32bit_impl` that displayed `str2optimizer8bit_blockwise.keys()` instead of `str2optimizer32bit.keys()`.
- Add LARS to the parametrized 32-bit optimizer tests in `test_optim.py`, using `PytorchLARS` as the reference implementation, with bf16 skip (matching momentum/rmsprop behavior since the momentum kernels lack a bf16 variant).

This builds on the approach from PR #1855 by @Mr-Neutr0n but also addresses the wrong error message, which was the second bug reported in the issue.

Fixes #1810

## Test plan
- [x] `pytest tests/test_optim.py -v --tb=short -k "lars"` — 8 passed, 4 skipped (bf16, expected)
- [x] `ruff check` and `ruff format` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)