### PR TITLE
cuda_specs.py: fix version tag string for ROCm/CUDA library lookup

### DIFF
--- a/bitsandbytes/cuda_specs.py
+++ b/bitsandbytes/cuda_specs.py
@@ -49,7 +49,7 @@ def get_cuda_version_string() -> Optional[str]:
     if version_tuple is None:
         return None
     major, minor = version_tuple
-    return f"{major * 10 + minor}"
+    return f"{major}{minor}"
 
 
 def get_cuda_specs() -> Optional[CUDASpecs]:


### PR DESCRIPTION
Replaced the incorrect `major * 10 + minor` logic (e.g. ROCm 7.12 → "82"; CUDA breaks when minor > 9) with simple string concatenation, producing the expected tags:
- ROCm 7.12 → "712"
- CUDA 12.4 → "124"

This makes version tag derivation consistent across CUDA and ROCm and fixes ROCm shared library name resolution (e.g. libbitsandbytes_rocm712.so). We should not use zero-padding (e.g. `{minor:02d}`), as that would change CUDA tags (e.g. 12.4 → "1204") .

Hope this helps.