### PR TITLE
Fix LARS/LAMB optimizer support and non-contiguous tensor handling on XPU

### DIFF
--- a/bitsandbytes/backends/default/ops.py
+++ b/bitsandbytes/backends/default/ops.py
@@ -357,9 +357,11 @@ ADEMAMIX = 5
 
 name2optimizer_id = {
     "momentum": MOMENTUM,
+    "lars": MOMENTUM,
     "rmsprop": RMSPROP,
     "adagrad": ADAGRAD,
     "adam": ADAM,
+    "lamb": ADAM,
     "lion": LION,
     "ademamix": ADEMAMIX,
 }

--- a/bitsandbytes/backends/triton/kernels_optim.py
+++ b/bitsandbytes/backends/triton/kernels_optim.py
@@ -123,7 +123,8 @@ def _optimizer_precondition_1state_32bit(
 
     if OPTIMIZER_ID == 0:  # MOMENTUM
         if step == 1:
-            s1_vals = g_vals
+            # Cast to fp32 to avoid type mismatch: s1_vals is fp32 but g_vals may be fp16.
+            s1_vals = g_vals.to(tl.float32)
         else:
             s1_vals = s1_vals * beta1 + g_vals
         update_norm = s1_vals * s1_vals

--- a/bitsandbytes/backends/triton/kernels_optim.py
+++ b/bitsandbytes/backends/triton/kernels_optim.py
@@ -24,9 +24,11 @@ ADEMAMIX = 5
 
 name2optimizer_id = {
     "momentum": MOMENTUM,
+    "lars": MOMENTUM,
     "rmsprop": RMSPROP,
     "adagrad": ADAGRAD,
     "adam": ADAM,
+    "lamb": ADAM,
     "lion": LION,
     "ademamix": ADEMAMIX,
 }
@@ -313,11 +315,19 @@ name2optimizer_32bit_fn = {
         "preprocess": _optimizer_precondition_2state_32bit,
         "update": _optimizer_update_2state_32bit_triton_kernel,
     },
+    "lamb": {
+        "preprocess": _optimizer_precondition_2state_32bit,
+        "update": _optimizer_update_2state_32bit_triton_kernel,
+    },
     "ademamix": {
         "preprocess": _optimizer_precondition_2state_32bit,
         "update": _optimizer_update_2state_32bit_triton_kernel,
     },
     "momentum": {
+        "preprocess": _optimizer_precondition_1state_32bit,
+        "update": _optimizer_update_1state_32bit_triton_kernel,
+    },
+    "lars": {
         "preprocess": _optimizer_precondition_1state_32bit,
         "update": _optimizer_update_1state_32bit_triton_kernel,
     },
@@ -1065,9 +1075,11 @@ def _optimizer_update_2state_8bit_blockwise_triton_kernel(
 
 name2optimizer_fn = {
     "momentum": _optimizer_update_1state_8bit_blockwise_triton_kernel,
+    "lars": _optimizer_update_1state_8bit_blockwise_triton_kernel,
     "rmsprop": _optimizer_update_1state_8bit_blockwise_triton_kernel,
     "adagrad": _optimizer_update_1state_8bit_blockwise_triton_kernel,
     "adam": _optimizer_update_2state_8bit_blockwise_triton_kernel,
+    "lamb": _optimizer_update_2state_8bit_blockwise_triton_kernel,
     "lion": _optimizer_update_1state_8bit_blockwise_triton_kernel,
     "ademamix": _optimizer_update_2state_8bit_blockwise_triton_kernel,
 }

--- a/bitsandbytes/backends/triton/ops.py
+++ b/bitsandbytes/backends/triton/ops.py
@@ -18,7 +18,7 @@ def quantize_blockwise(A: torch.Tensor, code: torch.Tensor, blocksize: int) -> t
     torch._check_is_size(blocksize)
     # torch._check(A.dtype == torch.float32, lambda: f"A must be float32 on xpu, got {A.dtype}")
     with torch_accelerator_module.device(A.device):
-        out, absmax = kernels_8bit_quant.quantize_blockwise_triton(A, code, blocksize)
+        out, absmax = kernels_8bit_quant.quantize_blockwise_triton(A.contiguous(), code, blocksize)
         return out, absmax.float()
 
 
@@ -30,7 +30,7 @@ def dequantize_blockwise(
     # torch._check(dtype == torch.float32, lambda: f"dtype must be float32 on xpu, got {dtype}")
     with torch_accelerator_module.device(A.device):
         out = kernels_8bit_quant.dequant_8bit_blockwise(
-            A,
+            A.contiguous(),
             absmax,
             code,
             blocksize,


### PR DESCRIPTION
## Changes

- **Enable LARS/LAMB optimizers on XPU**: Added missing `"lars"` and `"lamb"` entries to `name2optimizer_id`, `name2optimizer_32bit_fn`, and `name2optimizer_fn` dicts in the Triton backend, and `name2optimizer_id` in the default backend. LARS maps to `MOMENTUM` (1-state) and LAMB maps to `ADAM` (2-state).

- **Fix Triton compilation error with fp16 gradients**: In `_optimizer_precondition_1state_32bit`, the MOMENTUM branch's `step == 1` path does `s1_vals = g_vals` (direct assignment). When gradients are fp16, this changes `s1_vals` from fp32 to fp16, conflicting with the `else` branch where arithmetic auto-promotes to fp32. Fixed by casting `g_vals` to fp32 at the assignment site.

- **Fix non-contiguous tensor support for blockwise quantization**: Triton kernels use linear offsets to access memory, which is incorrect for non-contiguous tensors. Added `.contiguous()` calls in `quantize_blockwise` and `dequantize_blockwise` entry points.


Related tests:
```
pytest -k "xpu" -ra test_ops.py::TestNonContiguousInputs::test_quantize_blockwise_non_contiguous
pytest -k "xpu" -ra test_optim.py::test_optimizer32bit
```

Hi @matthewdouglas . Would you please review this PR? Thanks!