### PR TITLE
Fix XPU dequantize ops for non-contiguous tensors

### DIFF
--- a/bitsandbytes/backends/xpu/ops.py
+++ b/bitsandbytes/backends/xpu/ops.py
@@ -32,6 +32,8 @@ def _dequantize_4bit_impl(
     dtype: torch.dtype,
     out: torch.Tensor,
 ) -> None:
+    # XPU SYCL kernels only support contiguous tensors.
+    A = A.contiguous()
     args = (
         None,
         get_ptr(A),
@@ -61,6 +63,8 @@ def _dequantize_4bit_impl(
 def _dequantize_blockwise_impl(
     A: torch.Tensor, absmax: torch.Tensor, code: torch.Tensor, blocksize: int, dtype: torch.dtype, out: torch.Tensor
 ) -> None:
+    # XPU SYCL kernels only support contiguous tensors.
+    A = A.contiguous()
     args = (
         get_ptr(code),
         get_ptr(A),


### PR DESCRIPTION
## What does this PR do?

Adds `A.contiguous()` to `_dequantize_blockwise_impl` and `_dequantize_4bit_impl` in the XPU backend, matching the existing CUDA backend behavior. XPU SYCL kernels require contiguous memory layout; passing non-contiguous tensors produces silently incorrect results (99% element mismatch).

Hi @matthewdouglas . Please review this PR. Thanks!