### PR TITLE
fix: replace all instances of deprecated torch._check_is_size with torch._check

### DIFF
--- a/bitsandbytes/_ops.py
+++ b/bitsandbytes/_ops.py
@@ -183,7 +183,7 @@ def _(
     shape: Sequence[int],
     dtype: torch.dtype,
 ) -> torch.Tensor:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     return torch.empty(shape, dtype=dtype, device=A.device)
 
 
@@ -203,7 +203,7 @@ def _(
     dtype: torch.dtype,
     out: torch.Tensor,
 ) -> None:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     torch._check(out.shape == shape, lambda: f"Expected out.shape == {shape}, got {out.shape}")
     torch._check(out.device == A.device, lambda: f"Expected out.device == {A.device}, got {out.device}")
     torch._check(out.dtype == dtype, lambda: f"Expected out.dtype == {dtype}, got {out.dtype}")
@@ -219,7 +219,7 @@ torch.library.define(
 def _(
     A: torch.Tensor, blocksize: int, quant_type: str, quant_storage: torch.dtype
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
 
     n = A.numel()
     blocks = -(n // -blocksize)
@@ -236,7 +236,7 @@ torch.library.define(
 
 @register_fake("bitsandbytes::dequantize_blockwise")
 def _(A: torch.Tensor, absmax: torch.Tensor, code: torch.Tensor, blocksize: int, dtype: torch.dtype) -> torch.Tensor:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     torch._check(A.dtype == torch.uint8, lambda: f"A must be uint8, got {A.dtype}")
     return torch.empty_like(A, dtype=dtype)
 
@@ -251,7 +251,7 @@ torch.library.define(
 def _(
     A: torch.Tensor, absmax: torch.Tensor, code: torch.Tensor, blocksize: int, dtype: torch.dtype, out: torch.Tensor
 ):
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     torch._check(A.dtype == torch.uint8, lambda: f"A must be uint8, got {A.dtype}")
     torch._check(out.shape == A.shape, lambda: f"Expected out.shape == {A.shape}, got {out.shape}")
     torch._check(out.device == A.device, lambda: f"Expected out.device == {A.device}, got {out.device}")
@@ -263,7 +263,7 @@ torch.library.define("bitsandbytes::quantize_blockwise", "(Tensor A, Tensor code
 
 @register_fake("bitsandbytes::quantize_blockwise")
 def _(A: torch.Tensor, code: torch.Tensor, blocksize: int) -> tuple[torch.Tensor, torch.Tensor]:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     n = A.numel()
     blocks = -(n // -blocksize)
     absmax = torch.empty((blocks,), device=A.device, dtype=torch.float32)
@@ -281,7 +281,7 @@ torch.library.define(
 def _(
     A: torch.Tensor, B: torch.Tensor, shapeB: Sequence[int], absmax: torch.Tensor, code: torch.Tensor, blocksize: int
 ) -> torch.Tensor:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     torch._check(A.numel() == A.size(-1), lambda: f"A must be a vector with leading dimensions of 1, got {A.shape}")
     torch._check(
         A.dtype in [torch.float16, torch.bfloat16, torch.float32],
@@ -311,7 +311,7 @@ def _(
     blocksize: int,
     out: torch.Tensor,
 ) -> None:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     torch._check(A.numel() == A.size(-1), lambda: f"A must be a vector with leading dimensions of 1, got {A.shape}")
     torch._check(
         A.dtype in [torch.float16, torch.bfloat16, torch.float32],

--- a/bitsandbytes/backends/cpu/ops.py
+++ b/bitsandbytes/backends/cpu/ops.py
@@ -35,7 +35,7 @@ if not isinstance(lib, ErrorHandlerMockBNBNativeLibrary):
 
     @register_kernel("bitsandbytes::quantize_blockwise", "cpu")
     def _(A: torch.Tensor, code: torch.Tensor, blocksize: int) -> tuple[torch.Tensor, torch.Tensor]:
-        torch._check_is_size(blocksize)
+        torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
 
         n = A.numel()
         blocks = -(n // -blocksize)
@@ -94,7 +94,7 @@ if not isinstance(lib, ErrorHandlerMockBNBNativeLibrary):
     def _(
         A: torch.Tensor, absmax: torch.Tensor, code: torch.Tensor, blocksize: int, dtype: torch.dtype
     ) -> torch.Tensor:
-        torch._check_is_size(blocksize)
+        torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
         torch._check(A.dtype == torch.uint8, lambda: f"A must be uint8, got {A.dtype}")
 
         out = torch.empty_like(A, dtype=dtype)
@@ -146,7 +146,7 @@ if not isinstance(lib, ErrorHandlerMockBNBNativeLibrary):
         shape: Sequence[int],
         dtype: torch.dtype,
     ) -> torch.Tensor:
-        torch._check_is_size(blocksize)
+        torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
         torch._check(quant_type in ("nf4", "fp4"), lambda: f"quant_type must be nf4 or fp4, got {quant_type}")
         torch._check(
             dtype in [torch.bfloat16, torch.float16, torch.float32],

--- a/bitsandbytes/backends/cuda/ops.py
+++ b/bitsandbytes/backends/cuda/ops.py
@@ -221,7 +221,7 @@ def _get_col_absmax(
 @register_kernel("bitsandbytes::quantize_blockwise", "cuda")
 def _(A: torch.Tensor, code: torch.Tensor, blocksize: int) -> tuple[torch.Tensor, torch.Tensor]:
     A = A.contiguous()
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
 
     torch._check(blocksize in [4096, 2048, 1024, 512, 256, 128, 64, 32])
 
@@ -464,7 +464,7 @@ def _gemv_4bit_impl(
     blocksize: int,
     out: torch.Tensor,
 ) -> None:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
 
     # Note: these checks are not strictly necessary, and cost more than they are worth, so they are commented out for now.
     # torch._check(

--- a/bitsandbytes/backends/default/ops.py
+++ b/bitsandbytes/backends/default/ops.py
@@ -175,7 +175,7 @@ def _(A: torch.Tensor, threshold=0.0):
 
 @register_kernel("bitsandbytes::quantize_blockwise", "default")
 def _(A: torch.Tensor, code: torch.Tensor, blocksize: int) -> tuple[torch.Tensor, torch.Tensor]:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
 
     n = A.numel()
     rem = n % blocksize
@@ -201,7 +201,7 @@ def _(A: torch.Tensor, code: torch.Tensor, blocksize: int) -> tuple[torch.Tensor
 
 @register_kernel("bitsandbytes::dequantize_blockwise", "default")
 def _(A: torch.Tensor, absmax: torch.Tensor, code: torch.Tensor, blocksize: int, dtype: torch.dtype) -> torch.Tensor:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     torch._check(A.dtype == torch.uint8, lambda: f"A must be uint8, got {A.dtype}")
 
     out = code[A.reshape(-1).int()]
@@ -220,7 +220,7 @@ def _(A: torch.Tensor, absmax: torch.Tensor, code: torch.Tensor, blocksize: int,
 def _(
     A: torch.Tensor, blocksize: int, quant_type: str, quant_storage: torch.dtype
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     torch._check(quant_type in ("nf4", "fp4"), lambda: f"quant_type must be nf4 or fp4, got {quant_type}")
     torch._check(
         A.dtype in [torch.bfloat16, torch.float16, torch.float32],
@@ -317,7 +317,7 @@ def _(
     shape: Sequence[int],
     dtype: torch.dtype,
 ) -> torch.Tensor:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     torch._check(quant_type in ("nf4", "fp4"), lambda: f"quant_type must be nf4 or fp4, got {quant_type}")
     torch._check(
         dtype in [torch.bfloat16, torch.float16, torch.float32],

--- a/bitsandbytes/backends/hpu/ops.py
+++ b/bitsandbytes/backends/hpu/ops.py
@@ -25,7 +25,7 @@ def _(
     shape: Sequence[int],
     dtype: torch.dtype,
 ) -> torch.Tensor:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     torch._check(quant_type == "nf4", lambda: f"quant_type must be nf4, got {quant_type}")
     torch._check(
         A.dtype in [torch.bfloat16, torch.uint8],

--- a/bitsandbytes/backends/triton/ops.py
+++ b/bitsandbytes/backends/triton/ops.py
@@ -15,7 +15,7 @@ torch_accelerator_module = getattr(torch, device_type, torch.cuda)
 
 
 def quantize_blockwise(A: torch.Tensor, code: torch.Tensor, blocksize: int) -> tuple[torch.Tensor, torch.Tensor]:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     # torch._check(A.dtype == torch.float32, lambda: f"A must be float32 on xpu, got {A.dtype}")
     with torch_accelerator_module.device(A.device):
         out, absmax = kernels_8bit_quant.quantize_blockwise_triton(A.contiguous(), code, blocksize)
@@ -25,7 +25,7 @@ def quantize_blockwise(A: torch.Tensor, code: torch.Tensor, blocksize: int) -> t
 def dequantize_blockwise(
     A: torch.Tensor, absmax: torch.Tensor, code: torch.Tensor, blocksize: int, dtype: torch.dtype
 ) -> torch.Tensor:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     torch._check(A.dtype == torch.uint8, lambda: f"A must be uint8, got {A.dtype}")
     # torch._check(dtype == torch.float32, lambda: f"dtype must be float32 on xpu, got {dtype}")
     with torch_accelerator_module.device(A.device):
@@ -47,7 +47,7 @@ def dequantize_blockwise_inplace(
     dtype: torch.dtype,
     out: torch.Tensor,
 ) -> None:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     torch._check(A.dtype == torch.uint8, lambda: f"A must be uint8, got {A.dtype}")
     torch._check(out.shape == A.shape, lambda: f"Expected out.shape == {A.shape}, got {out.shape}")
     torch._check(out.device == A.device, lambda: f"Expected out.device == {A.device}, got {out.device}")
@@ -67,7 +67,7 @@ def dequantize_blockwise_inplace(
 def quantize_4bit(
     A: torch.Tensor, blocksize: int, quant_type: str, quant_storage: torch.dtype
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     # torch._check(quant_type == "nf4", lambda: f"quant_type must be nf4 on CPU, got {quant_type}")
     torch._check(
         A.dtype in [torch.bfloat16, torch.float16, torch.float32],
@@ -109,7 +109,7 @@ def dequantize_4bit(
     shape: Sequence[int],
     dtype: torch.dtype,
 ) -> torch.Tensor:
-    torch._check_is_size(blocksize)
+    torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
     # torch._check(quant_type == "nf4", lambda: f"quant_type must be nf4 on XPU, got {quant_type}")
     torch._check(
         dtype in [torch.bfloat16, torch.float16, torch.float32],


### PR DESCRIPTION
## Summary

Closes #1933.

PyTorch's `torch._check_is_size` is being removed in a future release per pytorch/pytorch#169400 — the FutureWarning advises "Use `_check(i >= 0)` instead". This PR finds / replaces all older approach instances with the recommended substitution.

## Scope

23 occurrences across 6 files:

| File | Hits |
|---|---|
| `bitsandbytes/_ops.py` | 8 |
| `bitsandbytes/backends/triton/ops.py` | 5 |
| `bitsandbytes/backends/default/ops.py` | 4 |
| `bitsandbytes/backends/cpu/ops.py` | 3 |
| `bitsandbytes/backends/cuda/ops.py` | 2 |
| `bitsandbytes/backends/hpu/ops.py` | 1 |

Each call `torch._check_is_size(blocksize)` is replaced with the upstream-recommended pattern:

```python
torch._check(blocksize >= 0, lambda: f"Blocksize must be non-negative, got {blocksize}")
```

This matches the existing `torch._check(...)` style already used at adjacent lines in the same files.

## Backwards compatibility

`torch._check` is available in all `torch >= 2.0`; bitsandbytes requires `torch >= 2.2` per `pyproject.toml`. No backwards-compat shim needed.

## Test plan

- `pre-commit run --files <changed>` passes (ruff + ruff-format + hygiene hooks)
- Replacement string verified at all 23 sites (count delta zero: 23 removed, 23 added)
- Diff preserves indentation; no other code paths touched

## Additional audits

*Audit structure adopted from @rapsealk's #1931 (asserts → exceptions refactor) for similar mechanical-substitution PRs.*

- `python -m py_compile` on all 6 changed files: all pass
- No leftover `torch._check_is_size` anywhere in `bitsandbytes/` after the substitution (count went 23 → 0)
- Argument variable is `blocksize` at all 23 sites — no slip in argument naming
- Call-site context: every call sits inside either a `@register_fake(...)` (FakeTensor / dispatch hook) or a `@register_kernel(...)` (backend kernel impl) decorator

## Semantic equivalence under SymInt (FakeTensor / torch.compile)

`_check_is_size(i)` does two things: (1) asserts `i >= 0`, and (2) informs PyTorch's dynamic-shape engine that `i` is a size (i.e., non-negative). The substitution `_check(blocksize >= 0, ...)` preserves both behaviors:

- For plain Python `int`, both produce identical runtime checks.
- For `SymInt` (which can flow through `register_fake` under torch.compile), `blocksize >= 0` evaluates to `SymBool` and `torch._check` of a `SymBool` informs the dynamic-shape engine of the same `>= 0` guard.

This matches the upstream migration explicitly recommended in pytorch/pytorch#169400 ("Use `_check(i >= 0)` instead").

## Out of scope

- `csrc/` (C++/CUDA) — `_check_is_size` is a Python-only API
- `tests/` and `examples/` — no calls to `_check_is_size` outside `bitsandbytes/` package code
