### PR TITLE
docs(install): note aarch64 wheels are aarch64-sbsa, not L4T (Jetson)

### DIFF
--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -66,6 +66,14 @@ Use `pip` or `uv` to install the latest release:
 pip install bitsandbytes
 ```
 
+> [!WARNING]
+> **NVIDIA Jetson (L4T / JetPack) — source build required.** The `Linux aarch64` wheels above are built on aarch64-sbsa runners (server-class ARM with the standard CUDA Toolkit). They are **not compatible** with the L4T runtime on Jetson devices (Orin Nano / NX / AGX, Xavier, Thor on CUDA 12), even though both are aarch64 and even though the cubins are binary-compatible with the device's compute capability (e.g., `sm_80` cubin runs on `sm_87` hardware via Ampere-family binary compat — see [NVIDIA's docs on binary compatibility](https://developer.nvidia.com/blog/understanding-ptx-the-assembly-language-of-cuda-gpu-computing/#binary_compatibility)). The mismatch is at the CUDA library / ABI layer (JetPack ships its own CUDA Toolkit and system libraries), and surfaces as a runtime symbol-resolution error like `Error named symbol not found in /src/csrc/ops.cu` on the first CUDA op.
+>
+> **Two working options on Jetson:**
+>
+> 1. **Source build on-device.** Use the [Compile from Source](#cuda-compile) instructions below, passing your device's compute capability explicitly (sm_87 for Orin family, sm_72 for Xavier). On an Orin Nano Super: `cmake -DCOMPUTE_BACKEND=cuda -DCOMPUTE_CAPABILITY=87 . && make -j4 && pip install .`
+> 2. **Third-party prebuilt** from [Jetson AI Lab's package index](https://pypi.jetson-ai-lab.io/) (e.g., `pypi.jetson-ai-lab.io/jp6/cu126/bitsandbytes/`).
+
 ### Compile from Source[[cuda-compile]]
 
 > [!TIP]


### PR DESCRIPTION
## Summary

Adds a short WARNING callout to `docs/source/installation.mdx` right after the Linux aarch64 row of the PyPI build-targets table, telling users that aarch64 wheels are built on **aarch64-sbsa** (server ARM with the standard CUDA Toolkit) — **not** the **L4T / JetPack** runtime that Jetson Orin / Xavier / Thor on CUDA 12 use. Points readers at the working options: on-device source build, or [Jetson AI Lab's prebuilt index](https://pypi.jetson-ai-lab.io/).

## Why

Per @matthewdouglas's review on #1939 and the original report at #1930: the failure mode is a CUDA symbol-resolution error from the toolchain mismatch (aarch64-sbsa CUDA libs vs L4T-bundled CUDA libs), **not** a missing-arch kernel-image issue. sm_80 cubins are binary-compatible with sm_87 hardware via Ampere-family binary compat — empirically confirmed in the #1939 thread (built bnb with `-DCOMPUTE_CAPABILITY=80` only, verified `cuobjdump --list-elf` shows only `sm_80.cubin`, ran cleanly on sm_87 Jetson Orin).

Documenting the workaround is the lowest-effort thing that helps the next person hitting the symbol-not-found error find the right answer (source-build or JAL prebuilt) without chasing the arch list as I originally did.

## Scope

- Single file: `docs/source/installation.mdx`
- 8-line `> [!WARNING]` callout placed right after the Linux aarch64 PyPI row (line 67)
- No build matrix changes, no test changes, no library code changes

## Test plan

- `pre-commit run --files docs/source/installation.mdx` passes (typos checker confirms no typos in the new prose; format hooks pass)
- Markdown callout uses `> [!WARNING]` syntax matching existing usage in the same file

## References

- Original error reports: #1218 (Jetson AGX Orin) and #1930 (Jetson Orin Nano Super)
- Diagnostic discussion on toolchain-vs-arch: #1939 (closed PR — see thread for empirical sm_80-on-sm_87 confirmation)
- Linked third-party prebuilt: https://pypi.jetson-ai-lab.io/
