### PR TITLE
Fix `gemv_4bit` bfloat16 correctness on Intel Arc A-series (Alchemist) GPUs

### DIFF
--- a/csrc/xpu_kernels.h
+++ b/csrc/xpu_kernels.h
@@ -22,6 +22,7 @@ template <typename T, int TILE_SIZE, int NUM_PER_TH, int DATA_TYPE> class kDequa
 
 template <typename T, size_t GROUP_SIZE, size_t NUM_PER_THREAD, size_t SUBG_SIZE, int BITS> class kgemv_4bit_inference {
   public:
+    [[sycl::reqd_sub_group_size(SUBG_SIZE)]]
     SYCL_EXTERNAL void operator()(sycl::nd_item<1> item) const;
 
     kgemv_4bit_inference(


### PR DESCRIPTION
### Problem

`gemv_4bit` with NF4 produces huge numerical errors for `bfloat16` on Intel Arc A-series GPUs (e.g. A770), while `float16` works correctly. The mean absolute error for `bfloat16` is ~1000x larger than expected (MAE=12.89 vs 0.008 for fp16). This causes gibberish output during LLM inference with `bnb_4bit_compute_dtype=torch.bfloat16` on these GPUs.

### Root Cause

The `kgemv_4bit_inference` SYCL kernel assumes a sub-group size of 32 throughout its logic (lane indexing, vectorized loads, and `reduce_over_group` on the sub-group). However, the `[[sycl::reqd_sub_group_size]]` attribute was only placed on the command group lambda in `sycl_comp_kernel_submit`, which does **not** propagate to a named kernel functor's `operator()`. Without an explicit attribute on `operator()`, the compiler is free to choose a smaller sub-group size. On Alchemist hardware (which supports {8, 16, 32}), the compiler picks 8 for `bfloat16`, breaking the reduction step for `IN_FEATURES > 256`.

### Fix

Add `[[sycl::reqd_sub_group_size(SUBG_SIZE)]]` to `kgemv_4bit_inference::operator()` in `csrc/xpu_kernels.h`, ensuring the compiler always uses the intended sub-group size of 32.

Credit: Fix suggested by @matthewdouglas, verified on Intel Arc A770 by @Blackwood416 (no regressions, no performance degradation).

Fixes #1932
