### PR TITLE
Fix target specific option mismatch during OpenMP loop inlining under GCC 16

### DIFF
--- a/csrc/cpu_ops.cpp
+++ b/csrc/cpu_ops.cpp
@@ -323,7 +323,7 @@ void quantize_cpu_impl(float* code, const T* A, float* absmax, unsigned char* ou
         absmax[b] = absmax_block;
 
         if (absmax_block == 0.0f) {
-            std::fill(out + block_start, out + block_end, 0);
+            for (long long i = block_start; i < block_end; ++i) { out[i] = 0; }
             continue;
         }
 

--- a/csrc/cpu_ops.cpp
+++ b/csrc/cpu_ops.cpp
@@ -323,7 +323,9 @@ void quantize_cpu_impl(float* code, const T* A, float* absmax, unsigned char* ou
         absmax[b] = absmax_block;
 
         if (absmax_block == 0.0f) {
-            for (long long i = block_start; i < block_end; ++i) { out[i] = 0; }
+            for (long long i = block_start; i < block_end; ++i) {
+                out[i] = 0;
+            }
             continue;
         }
 


### PR DESCRIPTION
### Description
    On bleeding-edge Linux distributions (like Fedora 44) running GCC 16.1.1+, compilation of `csrc/cpu_ops.cpp` fails when using OpenMP and AVX-512 flags. 
  
    GCC 16 outlines OpenMP loop bodies into helper functions that do not always carry the parent's target attributes. When `std::fill` (marked `always_inline`) is called inside this loop, GCC reports a `target specific option mismatch` and aborts.
  
    This PR replaces the single call to `std::fill` with a standard `for` loop, eliminating the compiler's function inlining target mismatch.
  
    ### Error log
    ```
    FAILED: CMakeFiles/bitsandbytes.dir/csrc/cpu_ops.cpp.o
    /usr/include/c++/16/bits/stl_algobase.h:1001:5: error: inlining failed in call to ‘always_inline’ ‘void std::fill(_ForwardIterator, _ForwardIterator, const _Tp&) [with _ForwardIterator = unsigned char*; _Tp = int]’: target specific option mismatch
     1001 |     fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
          |     ^~~~
    /home/naoki/src/bitsandbytes/csrc/cpu_ops.cpp:326:22: note: called from here
      326 |             std::fill(out + block_start, out + block_end, 0);
          |             ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ```