### PR TITLE
docs(cuda): use Windows-native BNB_CUDA_VERSION guidance

### DIFF
--- a/bitsandbytes/cextension.py
+++ b/bitsandbytes/cextension.py
@@ -2,8 +2,8 @@ import ctypes as ct
 import functools
 import logging
 import os
-import platform
 from pathlib import Path
+import platform
 import re
 from typing import Optional
 

--- a/bitsandbytes/cextension.py
+++ b/bitsandbytes/cextension.py
@@ -2,6 +2,7 @@ import ctypes as ct
 import functools
 import logging
 import os
+import platform
 from pathlib import Path
 import re
 from typing import Optional
@@ -19,6 +20,12 @@ from bitsandbytes.cuda_specs import (
 logger = logging.getLogger(__name__)
 
 
+def _env_var_guidance(var_name: str, example_value: str) -> tuple[str, str]:
+    if platform.system() == "Windows":
+        return (f"set {var_name}={example_value}", f"set {var_name}=")
+    return (f"export {var_name}={example_value}", f"unset {var_name}")
+
+
 def get_cuda_bnb_library_path(cuda_specs: CUDASpecs) -> Path:
     """
     Get the disk path to the CUDA BNB native library specified by the
@@ -32,44 +39,46 @@ def get_cuda_bnb_library_path(cuda_specs: CUDASpecs) -> Path:
 
     cuda_override_value = os.environ.get("BNB_CUDA_VERSION")
     rocm_override_value = os.environ.get("BNB_ROCM_VERSION")
+    set_rocm, clear_rocm = _env_var_guidance("BNB_ROCM_VERSION", "<version>")
+    set_cuda, clear_cuda = _env_var_guidance("BNB_CUDA_VERSION", "<version>")
 
     if torch.version.hip:
         if cuda_override_value:
             if not rocm_override_value:
                 raise RuntimeError(
                     f"BNB_CUDA_VERSION={cuda_override_value} detected but this is not a CUDA build!\n"
-                    "Use BNB_ROCM_VERSION instead: export BNB_ROCM_VERSION=<version>\n"
-                    "Clear the variable and retry: unset BNB_CUDA_VERSION\n"
+                    f"Use BNB_ROCM_VERSION instead: {set_rocm}\n"
+                    f"Clear the variable and retry: {clear_cuda}\n"
                 )
             logger.warning(
                 f"WARNING: BNB_CUDA_VERSION={cuda_override_value} is set but ignored on this ROCm build. "
-                "Clear the variable: unset BNB_CUDA_VERSION",
+                f"Clear the variable: {clear_cuda}",
             )
         if rocm_override_value:
             library_name = re.sub(r"rocm\d+", f"rocm{rocm_override_value}", library_name, count=1)
             logger.warning(
                 f"WARNING: BNB_ROCM_VERSION={rocm_override_value} environment variable detected; loading {library_name}.\n"
                 "This can be used to load a bitsandbytes version built with a ROCm version that is different from the PyTorch ROCm version.\n"
-                "If this was unintended clear the variable and retry: unset BNB_ROCM_VERSION\n",
+                f"If this was unintended clear the variable and retry: {clear_rocm}\n",
             )
     elif torch.version.cuda:
         if rocm_override_value:
             if not cuda_override_value:
                 raise RuntimeError(
                     f"BNB_ROCM_VERSION={rocm_override_value} detected but this is not a ROCm build!\n"
-                    "Use BNB_CUDA_VERSION instead: export BNB_CUDA_VERSION=<version>\n"
-                    "Clear the variable and retry: unset BNB_ROCM_VERSION\n"
+                    f"Use BNB_CUDA_VERSION instead: {set_cuda}\n"
+                    f"Clear the variable and retry: {clear_rocm}\n"
                 )
             logger.warning(
                 f"WARNING: BNB_ROCM_VERSION={rocm_override_value} is set but ignored on this CUDA build. "
-                "Clear the variable: unset BNB_ROCM_VERSION",
+                f"Clear the variable: {clear_rocm}",
             )
         if cuda_override_value:
             library_name = re.sub(r"cuda\d+", f"cuda{cuda_override_value}", library_name, count=1)
             logger.warning(
                 f"WARNING: BNB_CUDA_VERSION={cuda_override_value} environment variable detected; loading {library_name}.\n"
                 "This can be used to load a bitsandbytes version built with a CUDA version that is different from the PyTorch CUDA version.\n"
-                "If this was unintended clear the variable and retry: unset BNB_CUDA_VERSION\n",
+                f"If this was unintended clear the variable and retry: {clear_cuda}\n",
             )
     else:
         if rocm_override_value or cuda_override_value:

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -118,6 +118,12 @@ cmake --build . --config Release
 pip install -e .   # `-e` for "editable" install, when developing BNB (otherwise leave that out)
 ```
 
+> [!TIP]
+> If your locally built CUDA toolkit version does not match the CUDA version bundled with your PyTorch wheel, bitsandbytes may still try to load the PyTorch-matched binary name first.
+> On Windows, you can point bitsandbytes at your locally built DLL for the current shell with:
+> `set BNB_CUDA_VERSION=<cuda-version-without-dots>`
+> For example, a local CUDA 13.2 build uses `set BNB_CUDA_VERSION=132`.
+
 Big thanks to [wkpark](https://github.com/wkpark), [Jamezo97](https://github.com/Jamezo97), [rickardp](https://github.com/rickardp), [akx](https://github.com/akx) for their amazing contributions to make bitsandbytes compatible with Windows.
 
 </hfoption>

--- a/tests/test_cuda_setup_evaluator.py
+++ b/tests/test_cuda_setup_evaluator.py
@@ -1,6 +1,8 @@
+import platform
+
 import pytest
 
-from bitsandbytes.cextension import BNB_BACKEND, get_cuda_bnb_library_path
+from bitsandbytes.cextension import BNB_BACKEND, _env_var_guidance, get_cuda_bnb_library_path
 from bitsandbytes.cuda_specs import CUDASpecs
 
 
@@ -31,6 +33,14 @@ def test_get_cuda_bnb_library_path_override(monkeypatch, cuda120_spec, caplog):
     assert "BNB_CUDA_VERSION" in caplog.text  # did we get the warning?
 
 
+def test_env_var_guidance_uses_platform_specific_commands(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    assert _env_var_guidance("BNB_CUDA_VERSION", "132") == ("set BNB_CUDA_VERSION=132", "set BNB_CUDA_VERSION=")
+
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    assert _env_var_guidance("BNB_CUDA_VERSION", "132") == ("export BNB_CUDA_VERSION=132", "unset BNB_CUDA_VERSION")
+
+
 @pytest.mark.skipif(BNB_BACKEND != "CUDA", reason="this test requires a CUDA backend")
 def test_get_cuda_bnb_library_path_rejects_rocm_override(monkeypatch, cuda120_spec):
     """BNB_ROCM_VERSION alone should be rejected on CUDA with a helpful error."""
@@ -49,6 +59,16 @@ def test_get_cuda_bnb_library_path_cuda_override_takes_priority(monkeypatch, cud
     assert "BNB_CUDA_VERSION" in caplog.text
     assert "BNB_ROCM_VERSION" in caplog.text
     assert "ignored on this CUDA build" in caplog.text
+
+
+@pytest.mark.skipif(BNB_BACKEND != "CUDA", reason="this test requires a CUDA backend")
+def test_get_cuda_bnb_library_path_override_uses_windows_guidance(monkeypatch, cuda120_spec, caplog):
+    monkeypatch.delenv("BNB_ROCM_VERSION", raising=False)
+    monkeypatch.setenv("BNB_CUDA_VERSION", "110")
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    assert get_cuda_bnb_library_path(cuda120_spec).stem == "libbitsandbytes_cuda110"
+    assert "set BNB_CUDA_VERSION=" in caplog.text
+    assert "unset BNB_CUDA_VERSION" not in caplog.text
 
 
 @pytest.fixture


### PR DESCRIPTION
docs(cuda): use Windows-native BNB_CUDA_VERSION guidance

## Summary
This updates CUDA override guidance to use platform-appropriate shell commands on Windows and documents the local source-build case where the toolkit version used for the native DLL does not match the CUDA version bundled with the installed PyTorch wheel.

## Problem
On Windows, bitsandbytes currently emits Unix-style guidance such as `unset BNB_CUDA_VERSION` and `export BNB_CUDA_VERSION=...` from `bitsandbytes/cextension.py`.

That is misleading for Windows users, especially in the common local-source-build workflow where:
- PyTorch reports one CUDA version for wheel compatibility (for example `cu130`)
- the local CUDA toolkit used for compilation is newer (for example CUDA 13.2)
- the built DLL therefore has a different suffix (for example `libbitsandbytes_cuda132.dll`)

In that situation, users may need `BNB_CUDA_VERSION` to point bitsandbytes at the locally built DLL, but the current warning text tells them to use Unix shell syntax even on Windows.

## Change
- add a small helper in `bitsandbytes/cextension.py` that formats env-var guidance per platform
- use `set VAR=...` / `set VAR=` on Windows instead of `export` / `unset`
- add targeted tests for the platform-specific guidance
- add a Windows source-build note to `docs/source/installation.mdx` covering the local toolkit / PyTorch CUDA version mismatch case

## Validation
Validated on Windows with:
- local source build using CUDA 13.2 -> `libbitsandbytes_cuda132.dll`
- local PyTorch reporting `2.12.0+cu130`
- `pytest tests/test_cuda_setup_evaluator.py -q`

The targeted tests pass, and the Windows warning text now suggests `set BNB_CUDA_VERSION=...` and `set BNB_CUDA_VERSION=` instead of Unix shell commands.
