### PR TITLE
perf: improve default/fallback backend implementation for blockwise quantization ops

### DIFF
--- a/bitsandbytes/backends/cpu/ops.py
+++ b/bitsandbytes/backends/cpu/ops.py
@@ -149,9 +149,13 @@ if not isinstance(lib, ErrorHandlerMockBNBNativeLibrary):
         shape_fallback = shape[-1] % 2 != 0
 
         if avx512_fallback or shape_fallback:
-            from ..default.ops import _dequantize_4bit_impl
+            from ..default.ops import _dequantize_4bit_compute
+            from ..utils import _get_4bit_code
 
-            return _dequantize_4bit_impl(A, absmax, blocksize, quant_type, shape, dtype)
+            if A.dtype != torch.uint8:
+                A = A.view(torch.uint8)
+            code = _get_4bit_code(quant_type, A.device)
+            return _dequantize_4bit_compute(A.reshape(-1), absmax, code, blocksize, shape, dtype)
 
         # Enable non uint8 dtype
         if A.dtype != torch.uint8:

--- a/bitsandbytes/backends/default/ops.py
+++ b/bitsandbytes/backends/default/ops.py
@@ -1,12 +1,12 @@
 from collections.abc import Sequence
-from functools import wraps
+from functools import cache, wraps
 from math import sqrt
 from typing import Optional
 
 import torch
 
 from ..._ops import register_kernel
-from ..utils import CODE
+from ..utils import _get_4bit_code
 
 
 def _try_torch_compile(func=None, **compile_kwargs):
@@ -179,125 +179,113 @@ def _(A: torch.Tensor, threshold=0.0):
 
 @register_kernel("bitsandbytes::quantize_blockwise", "default")
 def _(A: torch.Tensor, code: torch.Tensor, blocksize: int) -> tuple[torch.Tensor, torch.Tensor]:
-    n = A.numel()
+    A_flat = A.reshape(-1).float()
+    n = A_flat.numel()
     rem = n % blocksize
-    has_rem = rem > 0
-    blocks = n // blocksize + has_rem
-    absmax = torch.zeros((blocks,), device=A.device, dtype=torch.float32)
-    A_reshaped = A.reshape(n)
-    A_com = A_reshaped[: n - rem]
-    A_com_reshaped = A_com.reshape(n // blocksize, blocksize)
-    absmax[: blocks - has_rem] = torch.abs(A_com_reshaped).max(dim=-1)[0]
-    scaled_A = torch.clamp(A_com_reshaped * (1 / absmax[: blocks - has_rem].view(-1, 1)), -1, 1)
-    scaled_A = scaled_A.reshape(-1)
-    if has_rem:
-        absmax[-1] = torch.abs(A_reshaped[n - rem :]).max()
-        scaled_A_rem = torch.clamp(A_reshaped[n - rem :] * (1 / absmax[-1]), -1, 1)
-        scaled_A = torch.cat([scaled_A, scaled_A_rem], dim=0)
+    full = n - rem
+    blocks = full // blocksize
+    A_com = A_flat[:full].reshape(blocks, blocksize)
+    absmax = A_com.abs().max(dim=-1)[0]
+    scaled = torch.clamp(A_com * (1.0 / absmax.clamp(min=1e-38).view(-1, 1)), -1, 1).reshape(-1)
+    if rem:
+        am = A_flat[full:].abs().max().clamp(min=1e-38)
+        absmax = torch.cat([absmax, am.unsqueeze(0)])
+        scaled = torch.cat([scaled, torch.clamp(A_flat[full:] / am, -1, 1)])
+    sorted_code, order = torch.sort(code)
+    bounds = (sorted_code[:-1] + sorted_code[1:]) / 2
+    q = order[torch.bucketize(scaled, bounds, out_int32=True)].to(torch.uint8)
+    return q.reshape(A.shape), absmax
 
-    diff = torch.abs(scaled_A.unsqueeze(-1) - code.to(scaled_A.device))
-    out = torch.argmin(diff, dim=-1).to(torch.uint8).to(scaled_A.device).reshape(A.shape)
 
-    return out, absmax
+@_try_torch_compile(dynamic=True)
+def _dequantize_blockwise_compute(
+    A_flat: torch.Tensor, absmax: torch.Tensor, code: torch.Tensor, blocksize: int, dtype: torch.dtype
+):
+    n = A_flat.numel()
+    out = code[A_flat.to(torch.int64)]
+    rem = n % blocksize
+    if rem == 0:
+        out = (out.reshape(-1, blocksize) * absmax.view(-1, 1)).reshape(n)
+    else:
+        full = n - rem
+        blocks = full // blocksize
+        out = torch.cat(
+            [
+                (out[:full].reshape(blocks, blocksize) * absmax[:blocks].view(-1, 1)).reshape(full),
+                out[full:] * absmax[blocks],
+            ]
+        )
+    return out.to(dtype)
 
 
 @register_kernel("bitsandbytes::dequantize_blockwise", "default")
 def _(A: torch.Tensor, absmax: torch.Tensor, code: torch.Tensor, blocksize: int, dtype: torch.dtype) -> torch.Tensor:
-    out = code[A.reshape(-1).int()]
-    blocks = out.shape[-1] // blocksize
-    res = out.shape[-1] % blocksize
-    if res != 0:
-        out = torch.nn.functional.pad(out, (0, blocksize - res), mode="constant", value=0)
-    out = (out.view(-1, blocksize) * absmax.view(-1, 1)).to(dtype).reshape(-1)
-    out = out[: blocks * blocksize + res]
-    out = out.reshape(A.shape)
+    return _dequantize_blockwise_compute(A.reshape(-1), absmax, code, blocksize, dtype).reshape(A.shape)
 
-    return out
+
+@cache
+def _get_4bit_quantize_bounds(quant_type: str, device: torch.device):
+    code = _get_4bit_code(quant_type, device)
+    order = torch.argsort(code)
+    midpoints = (code[order[:-1]] + code[order[1:]]) / 2
+    return midpoints, order  # NF4 order is identity (sorted); FP4 needs remap
 
 
 @register_kernel("bitsandbytes::quantize_4bit", "default")
 def _(
     A: torch.Tensor, blocksize: int, quant_type: str, quant_storage: torch.dtype
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    n = A.numel()
-    full_blocks = n // blocksize
+    bounds, order = _get_4bit_quantize_bounds(quant_type, A.device)
+    A_flat = A.reshape(-1).float()
+    n = A_flat.numel()
     rem = n % blocksize
-    blocks = full_blocks + 1 if rem else full_blocks
-    absmax = torch.zeros((blocks,), device=A.device, dtype=torch.float32)
-    A_flattened = A.reshape(n)
-
-    # Scale full blocks of the tensor to [-1, 1]
-    A_full_blocks = A_flattened[: n - rem].reshape(n // blocksize, blocksize)
-    absmax[:full_blocks] = torch.abs(A_full_blocks).max(dim=-1)[0]
-    scaled = torch.clamp(A_full_blocks * (1 / absmax[:full_blocks].view(-1, 1)), -1, 1).reshape(-1)
-
-    # Scale any partial block
+    full = n - rem
+    blocks = full // blocksize
+    A_com = A_flat[:full].reshape(blocks, blocksize)
+    absmax = A_com.abs().max(dim=-1)[0]
+    scaled = torch.clamp(A_com * (1.0 / absmax.clamp(min=1e-38).view(-1, 1)), -1, 1).reshape(-1)
     if rem:
-        A_rem = A_flattened[-rem:]
-        absmax[-1] = torch.abs(A_rem).max()
-        scaled_rem = torch.clamp(A_rem * (1 / absmax[-1]), -1, 1)
-        scaled = torch.cat([scaled, scaled_rem], dim=0)
-
-    # Quantize with the lookup table
-    code = CODE[quant_type].to(scaled.device).to(scaled.dtype)
-    # Pad to even length so packing pairs all elements
-    if scaled.numel() % 2 != 0:
-        scaled = torch.nn.functional.pad(scaled, (0, 1), value=0.0)
-    quantized = torch.argmin(torch.abs(scaled.view(-1, 1) - code), dim=-1, keepdim=True).to(torch.uint8)
-
-    # Pack two quantized values per byte
-    packed = quantized[::2] << 4 | quantized[1::2]
-
+        am = A_flat[full:].abs().max().clamp(min=1e-38)
+        absmax = torch.cat([absmax, am.unsqueeze(0)])
+        scaled = torch.cat([scaled, torch.clamp(A_flat[full:] / am, -1, 1)])
+    if scaled.numel() % 2:
+        scaled = torch.nn.functional.pad(scaled, (0, 1))
+    q = torch.bucketize(scaled, bounds, out_int32=True)
+    if quant_type != "nf4":
+        q = order[q]
+    q8 = q.to(torch.uint8)
+    packed = ((q8[::2] << 4) | q8[1::2]).unsqueeze(1)
     if quant_storage != torch.uint8:
         packed = packed.squeeze().view(quant_storage).unsqueeze(1)
+    return packed, absmax
 
-    return packed, absmax.float()
 
-
-def _dequantize_4bit_impl(
-    A: torch.Tensor,
+@_try_torch_compile(dynamic=True)
+def _dequantize_4bit_compute(
+    A_flat: torch.Tensor,
     absmax: torch.Tensor,
+    code: torch.Tensor,
     blocksize: int,
-    quant_type: str,
     shape: Sequence[int],
     dtype: torch.dtype,
-) -> torch.Tensor:
-    # Enable non uint8 dtype
-    if A.dtype != torch.uint8:
-        A = A.view(torch.uint8)
-
-    A = A.reshape(-1)
-    # Map nf4 to [-1, 1]
-    out_dq = torch.empty(A.size(0) * 2, dtype=torch.int32, device=A.device)
-    out_dq[1::2] = A & 0xF
-    out_dq[::2] = A >> 4
-    # code is fp32, cast to dtype to avoid the mismatch issue
-    code = CODE[quant_type].to(dtype).to(A.device)
-    out_dq = code[out_dq]
-
-    # Use the actual output size, not the unpacked size (which may include padding)
+):
     n = 1
     for s in shape:
         n *= s
-    # Trim any extra elements from padding during quantization
-    out_dq = out_dq[:n]
-
-    # Apply scales
-    blocks = n // blocksize
-    blocks += 1 if n % blocksize > 0 else 0
+    out_dq = torch.empty(A_flat.size(0) * 2, dtype=torch.int32, device=A_flat.device)
+    out_dq[1::2] = A_flat & 0xF
+    out_dq[::2] = A_flat >> 4
+    out_dq = code[out_dq][:n]  # stays fp32, matches C++ / CUDA behavior
     rem = n % blocksize
-    has_rem = rem > 0
-
-    out = torch.empty(shape, dtype=dtype, device=A.device).reshape(-1)
-    if has_rem:
-        out[: n - rem] = (out_dq[: n - rem].view(-1, blocksize) * absmax[: blocks - has_rem].view(-1, 1)).reshape(-1)
-        out[n - rem :] = out_dq[n - rem :] * absmax[-1]
+    if rem:
+        full = n - rem
+        blocks = full // blocksize
+        out = torch.empty(n, dtype=torch.float32, device=A_flat.device)
+        out[:full] = (out_dq[:full].view(-1, blocksize) * absmax[:blocks].view(-1, 1)).reshape(full)
+        out[full:] = out_dq[full:] * absmax[blocks]
     else:
-        out = out_dq.view(-1, blocksize) * absmax.view(-1, 1)
-
-    out = out.reshape(-1, *shape[1:]).to(dtype)
-
-    return out
+        out = (out_dq.view(-1, blocksize) * absmax.view(-1, 1)).reshape(n)
+    return out.reshape(-1, *shape[1:]).to(dtype)
 
 
 @register_kernel("bitsandbytes::dequantize_4bit", "default")
@@ -309,7 +297,10 @@ def _(
     shape: Sequence[int],
     dtype: torch.dtype,
 ) -> torch.Tensor:
-    return _dequantize_4bit_impl(A, absmax, blocksize, quant_type, shape, dtype)
+    if A.dtype != torch.uint8:
+        A = A.view(torch.uint8)
+    code = _get_4bit_code(quant_type, A.device)
+    return _dequantize_4bit_compute(A.reshape(-1), absmax, code, blocksize, shape, dtype)
 
 
 @register_kernel("bitsandbytes::gemv_4bit", "default")

--- a/bitsandbytes/backends/default/ops.py
+++ b/bitsandbytes/backends/default/ops.py
@@ -191,9 +191,8 @@ def _(A: torch.Tensor, code: torch.Tensor, blocksize: int) -> tuple[torch.Tensor
         am = A_flat[full:].abs().max().clamp(min=1e-38)
         absmax = torch.cat([absmax, am.unsqueeze(0)])
         scaled = torch.cat([scaled, torch.clamp(A_flat[full:] / am, -1, 1)])
-    sorted_code, order = torch.sort(code)
-    bounds = (sorted_code[:-1] + sorted_code[1:]) / 2
-    q = order[torch.bucketize(scaled, bounds, out_int32=True)].to(torch.uint8)
+    bounds = (code[:-1] + code[1:]) / 2  # code is always sorted (same assumption as CUDA kernel)
+    q = torch.bucketize(scaled, bounds, out_int32=True).to(torch.uint8)
     return q.reshape(A.shape), absmax
 
 


### PR DESCRIPTION
Improves the four ops for blockwise quantization/dequantization on the default/fallback backend. These ops would be used when no device-specific implementation is available. For CPU, one of these four ops applies (`quantize_4bit`). On MPS and PrivateUse1 devices like HPU, more of them will apply.

This does not impact CUDA/ROCm/XPU implementations.

### Impacted ops

| Op | CPU | MPS | HPU | Other PrivateUse1 |
|---|---|---|---|---|
| `quantize_4bit` | ✓ | ✓ * | ✓ | ✓ |
| `quantize_blockwise` | - | ✓ | ✓ | ✓ |
| `dequantize_blockwise` | - | ✓ | ✓ | ✓ |
| `dequantize_4bit` | - | ✓ * | - | ✓ |

The ops marked with `*` can have impact on MPS, pending a planned follow-up PR. These will likely become fallbacks to kernels hosted on `kernels-community`, which only builds for macOS 26+ and will fail on macOS 15 or without `kernels` installed.

On impacted devices devices, these ops are used for:
- **Model loading**: `quantize_4bit` and `quantize_blockwise` (nested absmax compression)
- **Inference/Training**: `dequantize_blockwise` (nested absmax decompression), `dequantize_4bit`
- **8-bit optimizers**: `quantize_blockwise` + `dequantize_blockwise` for optimizer state

---

#### `quantize_4bit`

**This is the only op without a CPU C++ kernel**, so improvements apply directly to CPU users quantizing models.

**Before:** Excessive intermediate memory, causing OOM on large models.
**After:** Reduced memory usage throughout with better performance. Also fixes a division-by-zero on all-zero weight blocks.

<sub>Ryzen 7950X, PyTorch 2.12.0, NF4, blocksize=64, bf16 input</sub>
| Shape | Before | After |
|---|---|---|
| 1024x4096 | 15ms / 136MB | 9ms / 30MB |
| 4096x4096 | 236ms / 2112MB | 45ms / 128MB |
| 8192x7168 | 808ms / 7616MB | 155ms / 448MB |
| 28672x8192 | OOM | ~600ms / ~1.8GB |

---

#### `quantize_blockwise`

**Before:** Excessive intermediate memory.
**After:** Reduced memory usage throughout, and better performance.

<sub>Ryzen 7950X, PyTorch 2.12.0, fp32, blocksize=256</sub>

| Shape | Before | After |
|---|---|---|
| 1024x4096 | 193ms / 2GB | 2ms / 9MB |
| 4096x4096 | 3000ms / 32GB | 80ms / 144MB |
| 8192x7168 | OOM | 277ms / 504MB |

*CPU data is illustrative of default implementation improvements; C++ kernels handle CPU in practice.*

---

#### `dequantize_blockwise`

**Before:** Unnecessary overhead and excess memory usage.
**After:** Cleaner implementation with reduced memory, improved throughput.

<sub>Ryzen 7950X, PyTorch 2.12.0, fp32, blocksize=256</sub>
| Shape | Before | After |
|---|---|---|
| 1024x4096 | 2ms / 12MB | 0.1ms / 4MB |
| 4096x4096 | 33ms / 192MB | 13ms / 64MB |
| 8192x7168 | 109ms / 672MB | 43ms / 224MB |

*CPU data is illustrative - separate C++ kernels handle CPU in practice.*

 <sub>MPS: M4, macOS 15, PyTorch 2.12.0, fp32, blocksize=256</sub>
  | Shape | Before | After |
  |---|---|---|
  | 4096x4096 | 8.44ms / 128MB | 0.59ms / 32MB |

---

#### `dequantize_4bit`

**Before:** Intermediate computation in lower precision, producing slightly different results
from the C++ and CUDA kernels.
**After:** Matches C++/CUDA precision. Improved throughput via `torch.compile`.

<sub>Ryzen 7950X, PyTorch 2.12.0 — NF4, blocksize=64, bf16 output</sub>
| Shape | Before | After |
|---|---|---|
| 1024x4096 | 7ms / 14MB | 0.5ms / 2MB |
| 4096x4096 | 42ms / 224MB | 7ms / 32MB |
| 8192x7168 | 140ms / 784MB | 24ms / 112MB |

*CPU data is illustrative - separate C++ kernels handle CPU in practice.*
