### PR TITLE
CMake: drop invalid gfx1153 from default HIP architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,8 @@ elseif(BUILD_HIP)
     elseif(AMDGPU_TARGETS AND NOT CMAKE_HIP_ARCHITECTURES)
       set(CMAKE_HIP_ARCHITECTURES ${AMDGPU_TARGETS})
     elseif(NOT CMAKE_HIP_ARCHITECTURES)
-      set(CMAKE_HIP_ARCHITECTURES "gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201")
+      # gfx1153 is not a valid target on ROCm 6.3 (clang: invalid target ID); drop it from defaults.
+      set(CMAKE_HIP_ARCHITECTURES "gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1152;gfx1200;gfx1201")
     endif()
 
     enable_language(HIP)


### PR DESCRIPTION

`gfx1153` is not a valid HIP target on ROCm 6.3 — clang rejects it with
`invalid target ID` — so it breaks the default HIP build. This removes `gfx1153`
from the default `CMAKE_HIP_ARCHITECTURES` list while keeping `gfx1201`
(RX 9070 / Navi 48) and the other supported targets.

Validated on AMD ROCm (gfx1201, ROCm 7.2.1): the default `-DCOMPUTE_BACKEND=hip`
configure no longer lists `gfx1153` and still includes `gfx1201`; both the
explicit `-DCMAKE_HIP_ARCHITECTURES=gfx1201` build and the default build produce
`libbitsandbytes_hip.so`.

Fixes #1955

---

*This is an experimental, AI-generated code change, reviewed by AMD engineers before submission.*
