### PR TITLE
Fix ROCm GPU arch detection: prefer torch device properties, robust hipInfo.exe lookup on Windows

### DIFF
--- a/bitsandbytes/cuda_specs.py
+++ b/bitsandbytes/cuda_specs.py
@@ -1,9 +1,11 @@
 import dataclasses
 from functools import lru_cache
 import logging
+import os
 import platform
 import re
 import subprocess
+import sys
 from typing import Optional
 
 import torch
@@ -82,30 +84,48 @@ def get_cuda_specs() -> Optional[CUDASpecs]:
 def get_rocm_gpu_arch() -> str:
     """Get ROCm GPU architecture."""
     logger = logging.getLogger(__name__)
-    try:
-        if torch.version.hip:
-            # On Windows, use hipinfo.exe; on Linux, use rocminfo
-            if platform.system() == "Windows":
-                cmd = ["hipinfo.exe"]
-                arch_pattern = r"gcnArchName:\s+gfx([a-zA-Z\d]+)"
-            else:
-                cmd = ["rocminfo"]
-                arch_pattern = r"Name:\s+gfx([a-zA-Z\d]+)"
 
+    if not torch.version.hip:
+        return "unknown"
+
+    # Prefer the architecture torch already knows; this needs no subprocess.
+    if torch.cuda.is_available():
+        try:
+            # gcnArchName may include feature flags, e.g. "gfx90a:sramecc+:xnack-".
+            return torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
+        except Exception as e:
+            logger.debug(f"Could not get ROCm GPU architecture from torch: {e}")
+
+    # Fall back to parsing tool output. On Windows, use hipInfo.exe; on Linux, use rocminfo.
+    if platform.system() == "Windows":
+        # hipInfo.exe is usually not on PATH: the HIP SDK does not add its bin directory,
+        # and AMD's PyTorch wheels for Windows ship hipInfo.exe next to python.exe instead.
+        cmds = [
+            ["hipinfo.exe"],
+            [os.path.join(os.path.dirname(sys.executable), "hipInfo.exe")],
+        ]
+        arch_pattern = r"gcnArchName:\s+gfx([a-zA-Z\d]+)"
+    else:
+        cmds = [["rocminfo"]]
+        arch_pattern = r"Name:\s+gfx([a-zA-Z\d]+)"
+
+    last_error: Optional[Exception] = None
+    for cmd in cmds:
+        try:
             result = subprocess.run(cmd, capture_output=True, text=True)
-            match = re.search(arch_pattern, result.stdout)
-            if match:
-                return "gfx" + match.group(1)
-            else:
-                return "unknown"
-        else:
-            return "unknown"
-    except Exception as e:
-        logger.error(f"Could not detect ROCm GPU architecture: {e}")
+        except Exception as e:
+            last_error = e
+            continue
+        match = re.search(arch_pattern, result.stdout)
+        if match:
+            return "gfx" + match.group(1)
+
+    if last_error is not None:
+        logger.error(f"Could not detect ROCm GPU architecture: {last_error}")
         if torch.cuda.is_available():
             logger.warning(
                 """
 ROCm GPU architecture detection failed despite ROCm being available.
                 """,
             )
-        return "unknown"
+    return "unknown"

--- a/tests/test_cuda_setup_evaluator.py
+++ b/tests/test_cuda_setup_evaluator.py
@@ -1,7 +1,10 @@
+from types import SimpleNamespace
+
 import pytest
+import torch
 
 from bitsandbytes.cextension import BNB_BACKEND, get_cuda_bnb_library_path
-from bitsandbytes.cuda_specs import CUDASpecs
+from bitsandbytes.cuda_specs import CUDASpecs, get_rocm_gpu_arch
 
 
 @pytest.fixture
@@ -96,3 +99,21 @@ def test_get_rocm_bnb_library_path_rejects_cuda_override(monkeypatch, rocm70_spe
     monkeypatch.setenv("BNB_CUDA_VERSION", "110")
     with pytest.raises(RuntimeError, match=r"BNB_CUDA_VERSION.*not a CUDA build"):
         get_cuda_bnb_library_path(rocm70_spec)
+
+
+def test_get_rocm_gpu_arch_from_torch(monkeypatch):
+    """With a visible GPU, the architecture comes from torch device properties, without a subprocess."""
+    monkeypatch.setattr(torch.version, "hip", "7.0.0")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda device: SimpleNamespace(gcnArchName="gfx90a:sramecc+:xnack-"),
+    )
+    assert get_rocm_gpu_arch() == "gfx90a"
+
+
+def test_get_rocm_gpu_arch_non_rocm(monkeypatch):
+    """On non-ROCm builds, no detection is attempted."""
+    monkeypatch.setattr(torch.version, "hip", None)
+    assert get_rocm_gpu_arch() == "unknown"


### PR DESCRIPTION
## Problem

On Windows ROCm setups, `get_rocm_gpu_arch()` probes `hipinfo.exe` with `subprocess.run(["hipinfo.exe"], ...)`, which resolves through `PATH` only. In practice `hipInfo.exe` is rarely reachable that way:

- Hosts without the HIP SDK don't have it on `PATH` at all.
- AMD's PyTorch wheels for Windows ship `hipInfo.exe` into the environment's `Scripts` directory (next to `python.exe`), which is only on `PATH` while the venv is activated — not when the interpreter is invoked directly, via `uv run`, or embedded.

The probe then raises `FileNotFoundError`, and **every** `import bitsandbytes` logs:

```
ERROR:bitsandbytes.cuda_specs:Could not detect ROCm GPU architecture: [WinError 2] The system cannot find the file specified
WARNING:bitsandbytes.cuda_specs:
ROCm GPU architecture detection failed despite ROCm being available.
```

while `ROCM_GPU_ARCH` silently degrades to `"unknown"` — even though the GPU works fine.

## Fix

1. **Prefer `torch.cuda.get_device_properties(0).gcnArchName`** — torch already knows the architecture on both Linux and Windows, with no subprocess at all. Feature-flag suffixes (e.g. `gfx90a:sramecc+:xnack-`) are stripped to keep the existing `"gfx..."` format. This introduces no new device initialization: importing bitsandbytes already initializes the device context in `cextension.py` via `get_cuda_specs()` → `torch.cuda.get_device_capability()`.
2. **Keep the `rocminfo` / `hipInfo.exe` parsing as a fallback**, and on Windows additionally try `hipInfo.exe` next to `python.exe` (where AMD's wheels place it) before giving up.
3. The ERROR/WARNING logging is preserved for genuine failures; behavior on non-ROCm builds is unchanged.

## Validation

On a Strix Halo (gfx1151) Windows 11 machine with AMD's wheels (`torch 2.11.0+rocm7.13.0`), venv **not** activated, so `Scripts` is not on `PATH` and `shutil.which("hipinfo.exe")` is `None`:

- **Before:** `ROCM_GPU_ARCH == "unknown"` plus the ERROR/WARNING above on import.
- **After:** the torch-properties path returns `gfx1151` with no log output; forcing the subprocess fallback (mocking `torch.cuda.is_available` to `False`) also returns `gfx1151` via the `Scripts`-relative `hipInfo.exe`.

Added two mocked unit tests that run on any backend. On the ROCm box:

```
tests/test_cuda_setup_evaluator.py: 6 passed, 4 skipped (CUDA-only)
```

All `pre-commit` hooks pass on the changed files.

## Context

- #1846 introduced the Windows `hipinfo.exe` probe (superseding #1843 / #1833, which reported this same failure mode); #1915 added the Windows ROCm wheels.
- Downstream, Unsloth currently works around this by prepending the venv `Scripts` directory to `PATH` before importing bitsandbytes (unslothai/unsloth#5940, commit f48fc9a). This PR fixes it at the source so downstream consumers don't need that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
