### PR TITLE
fix: ensure absmax_offset is of type float32 before passing to gemm_4bit

### DIFF
--- a/bitsandbytes/backends/cuda/ops.py
+++ b/bitsandbytes/backends/cuda/ops.py
@@ -867,6 +867,9 @@ if torch.version.hip is None:
         else:
             raise RuntimeError(f"unsupported dtype {A.dtype}")
 
+        # Offset is expected to be a float32 tensor.
+        absmax_offset_f32 = absmax_offset.to(dtype=torch.float32) if absmax_offset is not None else None
+
         with _cuda_device_of(A):
             fn(
                 A.data_ptr(),
@@ -874,7 +877,7 @@ if torch.version.hip is None:
                 absmax.data_ptr(),
                 absmax_8bit.data_ptr() if absmax_8bit is not None else None,
                 absmax_code.data_ptr() if absmax_code is not None else None,
-                absmax_offset.data_ptr() if absmax_offset is not None else None,
+                absmax_offset_f32.data_ptr() if absmax_offset_f32 is not None else None,
                 out.data_ptr(),
                 bias.data_ptr() if bias is not None else None,
                 M,

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -337,10 +337,7 @@ class Test4bitBlockwiseQuantOps:
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=describe_dtype)
     @pytest.mark.parametrize("offset_dtype", [torch.float16, torch.bfloat16], ids=describe_dtype)
     def test_gemm_4bit_non_float32_offset(self, device, dtype, offset_dtype):
-        """Regression test: offset tensors not in float32 must still produce correct results.
-
-        Pre-quantized models (e.g. Unsloth bnb-4bit) may store qs.offset in non-float32 dtype.
-        """
+        """Regression test: offset tensors not in float32 must still produce correct results."""
         N, K, blocksize = 64, 64, 64
         A = torch.randn(4, K, dtype=dtype, device=device)
         B = torch.randn(N, K, dtype=dtype, device=device)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -333,6 +333,50 @@ class Test4bitBlockwiseQuantOps:
                 kwargs={"bias": bias},
             )
 
+    @pytest.mark.parametrize("device", get_available_devices())
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=describe_dtype)
+    @pytest.mark.parametrize("offset_dtype", [torch.float16, torch.bfloat16], ids=describe_dtype)
+    def test_gemm_4bit_non_float32_offset(self, device, dtype, offset_dtype):
+        """Regression test: offset tensors not in float32 must still produce correct results.
+
+        Pre-quantized models (e.g. Unsloth bnb-4bit) may store qs.offset in non-float32 dtype.
+        """
+        N, K, blocksize = 64, 64, 64
+        A = torch.randn(4, K, dtype=dtype, device=device)
+        B = torch.randn(N, K, dtype=dtype, device=device)
+        B_q, qs = bitsandbytes.functional.quantize_4bit(
+            B, blocksize=blocksize, quant_type="nf4", compress_statistics=True
+        )
+
+        # Simulate a pre-quantized model where offset may not be float32.
+        offset_non_f32 = qs.offset.to(dtype=offset_dtype)
+
+        # Reference: explicitly use the rounded float32 value.
+        offset_as_f32 = offset_non_f32.to(dtype=torch.float32)
+        ref = torch.ops.bitsandbytes.gemm_4bit.default(
+            A,
+            B_q,
+            list(B.shape),
+            qs.state2.absmax,
+            blocksize,
+            "nf4",
+            absmax_8bit=qs.absmax,
+            absmax_code=qs.state2.code,
+            absmax_offset=offset_as_f32,
+        )
+        out = torch.ops.bitsandbytes.gemm_4bit.default(
+            A,
+            B_q,
+            list(B.shape),
+            qs.state2.absmax,
+            blocksize,
+            "nf4",
+            absmax_8bit=qs.absmax,
+            absmax_code=qs.state2.code,
+            absmax_offset=offset_non_f32,
+        )
+        torch.testing.assert_close(out, ref)
+
 
 class TestNonContiguousInputs:
     """Regression tests for #1342 and #1690: quantization must handle non-contiguous tensors correctly."""


### PR DESCRIPTION
# TLDR

`gemm_4bit` kernel functions expect a float32 `absmax_offset`, but the offsets from some pre-quantized models are bfloat16. The discrepancy leads to gibberish offset values in the kernel, which further affects the outputs.

Relevant package versions:
- torch: 2.10.0+cu128
- accelerate: 1.13.0
- transformers: 5.3.0

# Background

I was playing around with [Unsloth_Puzzles.ipynb](https://colab.research.google.com/drive/1JqKqA1XWeLHvnYAc0wzrR4JBCnq43HyH?usp=sharing) part B on RTX5070Ti (sm120) with the same model, `unsloth/meta-Llama-3.1-8B-Instruct-bnb-4bit`, when I noticed that the training loss values changed drastically after commit 5453368 "[CUDA] New 4bit GEMM kernels for inference (#1949)". Specifically, the loss starts off much larger and quickly becomes 0 (NaN values):

| Step | Training loss before 5453368 | Training loss after 5453368 |
|----------|----------|----------| 
| 1   |2.109375 | 7.015625 |
| 2   |2.343750 | 7.828125 |
| 3   |2.750000 | 11.593750 |
| 4   |2.015625 | 0.000000 |
| 5   |1.960938 | 0.000000 |
| 6   |1.945312 | 0.000000 |
| 7   |1.656250 | 0.000000 |
| 8   |1.750000 | 0.000000 |
| 9   |1.617188 | 0.000000 |
| 10 |1.882812 | 0.000000 |

*Note that the training loss before the mentioned commit is similar to that in the notebook.*

By trying out different models, I found that the loss values show the same issue when 1) a pre-quantized base model is used and 2) `gemm_4bit` is called (when [`use_custom` is `True`](https://github.com/bitsandbytes-foundation/bitsandbytes/blob/main/bitsandbytes/backends/cuda/ops.py#L871)). Some of the models I used are as follows:


| Model | Is affected | Is pre-quantized | `use_custom` is `True` |
|----------|----------|----------| ----------| 
|unsloth/meta-Llama-3.1-8B-Instruct-bnb-4bit| Yes|Yes|Yes |
|unsloth/gemma-3-270m-bnb-4bit|Yes|Yes|Yes|
|unsloth/gemma-3-270m|No|No|Yes|
|unsloth/Llama-3.2-3B-Instruct-bnb-4bit|No|Yes|No|


# Findings

The bug appears to be caused by the type of `absmax_offset`. The `absmax_offset` values coming from the pre-quantized models I've used so far are bfloat16, while the kernel function expects a float32 tensor. Consequently, the offset value becomes gibberish and extremely large, which causes overflow.

I've made a small change along with the corresponding test. The training loss for all the models mentioned above is now more stable. The model `unsloth/meta-Llama-3.1-8B-Instruct-bnb-4bit`, for instance, now gives the following outputs:

| Step | Training loss before 5453368 | Training loss after 5453368 | Training loss after the bug fix |
|----------|----------|----------| ----------| 
| 1   |2.109375 | 7.015625 | 2.109375 |
| 2   |2.343750 | 7.828125 | 2.335938 |
| 3   |2.750000 | 11.593750 | 2.755859 |
| 4   |2.015625 | 0.000000 | 2.013672 |
| 5   |1.960938 | 0.000000 | 1.948242 |
| 6   |1.945312 | 0.000000 | 1.929688 |
| 7   |1.656250 | 0.000000 | 1.637695 |
| 8   |1.750000 | 0.000000 | 1.728516 |
| 9   |1.617188 | 0.000000 | 1.561523 |
| 10 |1.882812 | 0.000000 | 1.808594 |

I've only tried Unsloth's pre-quantized models, so do let me know if there are other pre-quantized models you'd like me to try (or if there are other tests you'd like me to do).