### PR TITLE
Specify kernel `version` when loading CPU `gemm_4bit_forward` from the Hub

### DIFF
--- a/bitsandbytes/backends/cpu/ops.py
+++ b/bitsandbytes/backends/cpu/ops.py
@@ -242,7 +242,9 @@ if not isinstance(lib, ErrorHandlerMockBNBNativeLibrary):
         try:
             from kernels import get_kernel
 
-            gemm_4bit_forward_kernel = get_kernel("kernels-community/quantization_bitsandbytes").gemm_4bit_forward
+            gemm_4bit_forward_kernel = get_kernel(
+                "kernels-community/quantization-bitsandbytes", version=1
+            ).gemm_4bit_forward
         except Exception as exc:  # pragma: no cover - best effort fallback
             gemm_4bit_forward_kernel = None
             logger.warning(


### PR DESCRIPTION
## Description

Loading the CPU `gemm_4bit_forward` kernel from `kernels-community` fails with newer
`kernels` (>= 0.11.1), which now require an explicit kernel API `version` (or a Hub
`revision`) to be passed to `get_kernel`:

```
A kernel version or revision must be specified. Use `version=<major>` for a stable
kernel API version or `revision=<branch/tag/commit>` for an explicit Hub revision.
```

Without it, `get_kernel("kernels-community/quantization-bitsandbytes")` raises and the
CPU 4-bit fused path silently falls back to the slower native implementation.

## Fix

Pass the stable kernel API `version=1` (an `int`, matching the repo's `v1` build
branch) to `get_kernel`:

```diff
- gemm_4bit_forward_kernel = get_kernel(
-     "kernels-community/quantization-bitsandbytes"
- ).gemm_4bit_forward
+ gemm_4bit_forward_kernel = get_kernel(
+     "kernels-community/quantization-bitsandbytes", version=1
+ ).gemm_4bit_forward
```

## Notes

- `version` must be an integer (`1`), not a string; it resolves to the `v1` build
  branch published for this kernel.
- The load remains wrapped in `try/except`, so environments without `kernels`
  installed continue to fall back to the native CPU kernel.
