### PR TITLE
Fix diagnostics package version lookup

### DIFF
--- a/bitsandbytes/diagnostics/main.py
+++ b/bitsandbytes/diagnostics/main.py
@@ -1,7 +1,7 @@
-import importlib
 import platform
 import sys
 import traceback
+from importlib import metadata as importlib_metadata
 
 import torch
 
@@ -44,8 +44,8 @@ def sanity_check():
 
 def get_package_version(name: str) -> str:
     try:
-        version = importlib.metadata.version(name)
-    except importlib.metadata.PackageNotFoundError:
+        version = importlib_metadata.version(name)
+    except importlib_metadata.PackageNotFoundError:
         version = "not found"
     return version
 

--- a/tests/test_diagnostics_main.py
+++ b/tests/test_diagnostics_main.py
@@ -1,0 +1,18 @@
+from importlib import metadata as importlib_metadata
+
+from bitsandbytes.diagnostics import main
+
+
+def test_get_package_version_returns_installed_version(monkeypatch):
+    monkeypatch.setattr(main.importlib_metadata, "version", lambda name: "1.2.3")
+
+    assert main.get_package_version("pip") == "1.2.3"
+
+
+def test_get_package_version_returns_not_found_for_missing_package(monkeypatch):
+    def raise_package_not_found(name):
+        raise importlib_metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(main.importlib_metadata, "version", raise_package_not_found)
+
+    assert main.get_package_version("missing-package") == "not found"


### PR DESCRIPTION
## Summary
- switch diagnostics package version lookup to importlib.metadata`n- handle PackageNotFoundError through the imported metadata module
- add a focused regression test for installed and missing packages

## Why
get_package_version() currently calls importlib.metadata without importing the submodule first, so the helper can raise AttributeError before reaching its fallback path.

## Testing
- compiled the updated source files locally
- ran an isolated Python verification script that stubs heavy runtime dependencies and checks both installed and missing package paths

Issue linkage: not tied to an existing tracked issue.