### PR TITLE
Fix Lion to use decoupled weight decay (default + CUDA 32-bit)

### DIFF
--- a/bitsandbytes/backends/default/ops.py
+++ b/bitsandbytes/backends/default/ops.py
@@ -522,9 +522,6 @@ def _optimizer_update_32bit(
         # Lion uses decoupled weight decay: shrink the param directly (p *= 1 - lr*wd)
         # rather than folding wd into the gradient. Matches the cpu backend, the CUDA
         # 8-bit blockwise kernel, and the Lion paper (Chen et al. 2023).
-        # NOTE: the Triton 1-state kernel (backends/triton/kernels_optim.py) still
-        # applies *coupled* decay to Lion — the same bug this fixes — and needs a
-        # separate fix. The CUDA 32-bit kernel is fixed alongside this change.
         if weight_decay > 0.0:
             p_vals = p_vals * (1.0 - lr * weight_decay)
 

--- a/bitsandbytes/backends/default/ops.py
+++ b/bitsandbytes/backends/default/ops.py
@@ -450,7 +450,11 @@ def _optimizer_update_32bit(
 
     p_vals = p.float()
     g_vals = (gnorm_scale * g).float()
-    if optimizer_id in [0, 1, 2, 4] and weight_decay > 0.0:
+    # Coupled (L2) weight decay: fold wd into the gradient. This is correct for
+    # MOMENTUM/RMSPROP/ADAGRAD, but NOT for LION (id 4), which uses *decoupled*
+    # (AdamW-style) weight decay applied to the param directly (see the LION branch
+    # below and Chen et al. 2023). LION is intentionally excluded here.
+    if optimizer_id in [0, 1, 2] and weight_decay > 0.0:
         g_vals = g_vals + p_vals * weight_decay
 
     update_scale = 1.0
@@ -515,6 +519,15 @@ def _optimizer_update_32bit(
         state1.copy_(s1_vals)
 
     elif optimizer_id == 4:  # LION
+        # Lion uses decoupled weight decay: shrink the param directly (p *= 1 - lr*wd)
+        # rather than folding wd into the gradient. Matches the cpu backend, the CUDA
+        # 8-bit blockwise kernel, and the Lion paper (Chen et al. 2023).
+        # NOTE: the CUDA 32-bit kernel (csrc/kernels.cu::kOptimizer32bit1State) and the
+        # Triton 1-state kernel (backends/triton/kernels_optim.py) still apply *coupled*
+        # decay to Lion — the same bug this fixes — and need a separate upstream fix.
+        if weight_decay > 0.0:
+            p_vals = p_vals * (1.0 - lr * weight_decay)
+
         momentum_update = state1 * beta1 + (1.0 - beta1) * g_vals
         update_val = update_scale * lr * torch.sign(momentum_update)
         p_vals = p_vals - update_val

--- a/bitsandbytes/backends/default/ops.py
+++ b/bitsandbytes/backends/default/ops.py
@@ -522,9 +522,9 @@ def _optimizer_update_32bit(
         # Lion uses decoupled weight decay: shrink the param directly (p *= 1 - lr*wd)
         # rather than folding wd into the gradient. Matches the cpu backend, the CUDA
         # 8-bit blockwise kernel, and the Lion paper (Chen et al. 2023).
-        # NOTE: the CUDA 32-bit kernel (csrc/kernels.cu::kOptimizer32bit1State) and the
-        # Triton 1-state kernel (backends/triton/kernels_optim.py) still apply *coupled*
-        # decay to Lion — the same bug this fixes — and need a separate upstream fix.
+        # NOTE: the Triton 1-state kernel (backends/triton/kernels_optim.py) still
+        # applies *coupled* decay to Lion — the same bug this fixes — and needs a
+        # separate fix. The CUDA 32-bit kernel is fixed alongside this change.
         if weight_decay > 0.0:
             p_vals = p_vals * (1.0 - lr * weight_decay)
 

--- a/csrc/kernels.cu
+++ b/csrc/kernels.cu
@@ -858,7 +858,11 @@ __launch_bounds__(TH, 1) __global__ void kOptimizer32bit1State(
 #pragma unroll 4
         for (unsigned int j = 0; j < NUM_PER_THREAD; j++) {
             g_vals[j] = gnorm_scale * ((float)g_vals[j]);
-            if (weight_decay > 0.0f)
+            // Coupled (L2) weight decay folds decay into the gradient. Correct for
+            // MOMENTUM/RMSPROP/ADAGRAD, but NOT for LION, which uses decoupled
+            // (AdamW-style) decay applied to the param directly (see the LION branch
+            // below and Chen et al. 2023). This matches the CUDA 8-bit blockwise kernel.
+            if (weight_decay > 0.0f && OPTIMIZER != LION)
                 g_vals[j] = (float)g_vals[j] + (((float)p_vals[j]) * weight_decay);
         }
 
@@ -875,6 +879,10 @@ __launch_bounds__(TH, 1) __global__ void kOptimizer32bit1State(
                     p_vals[j] = ((float)p_vals[j]) + update_scale * (-lr * (s1_vals[j]));
                     break;
                 case LION:
+                    // Decoupled weight decay: shrink the param directly, outside the
+                    // sign update (Chen et al. 2023), matching the 8-bit blockwise kernel.
+                    if (weight_decay > 0.0f)
+                        p_vals[j] = ((float)p_vals[j]) * (1.0f - lr * weight_decay);
                     p_vals[j] =
                         ((float)p_vals[j]) -
                         update_scale * (lr * sgn(((float)s1_vals[j]) * beta1 + ((1.0f - beta1) * ((float)g_vals[j]))));

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -243,6 +243,55 @@ def test_optimizer32bit(dim1, dim2, gtype, optim_name, device):
             assert bnb_optimizer.state[p2]["unorm_vec"] > 0.0
 
 
+@pytest.mark.parametrize("gtype", [torch.float32, torch.float16, torch.bfloat16], ids=describe_dtype)
+@pytest.mark.parametrize("dim1", [1024], ids=id_formatter("dim1"))
+@pytest.mark.parametrize("dim2", [32, 1024], ids=id_formatter("dim2"))
+@pytest.mark.parametrize("device", get_available_devices(), ids=id_formatter("device"))
+def test_lion32bit_weight_decay(dim1, dim2, gtype, device):
+    """Lion must use *decoupled* weight decay (p *= 1 - lr*wd), matching the Lion paper
+    and the lion_pytorch reference.
+
+    Regression test for a coupled-vs-decoupled weight-decay bug: the shared 32-bit
+    optimizer path (used by the `default` backend, i.e. MPS and any device without a
+    dedicated kernel) folded weight decay into the gradient (coupled L2) for Lion, which
+    corrupts the sign update. The existing test_optimizer32bit never caught it because it
+    constructs optimizers with the default weight_decay=0, where the two forms coincide.
+    """
+    weight_decay = 0.1
+
+    p1 = torch.randn(dim1, dim2, device=device, dtype=gtype) * 0.1
+    p2 = p1.clone()
+    p1 = p1.float()
+
+    torch_optimizer = Lion([p1], weight_decay=weight_decay)
+    bnb_optimizer = bnb.optim.Lion([p2], weight_decay=weight_decay)
+
+    if gtype == torch.float32:
+        atol, rtol = 1e-6, 1e-5
+    elif gtype == torch.bfloat16:
+        atol, rtol = 1e-3, 1e-2
+    else:
+        atol, rtol = 1e-4, 1e-3
+
+    for i in range(k):
+        g = torch.randn(dim1, dim2, device=device, dtype=gtype) * 0.01
+        p1.grad = g.clone().float()
+        p2.grad = g.clone()
+
+        bnb_optimizer.step()
+        torch_optimizer.step()
+
+        # Lion's sign update is noisy at boundaries, so allow a few mismatches (matches
+        # the tolerance policy in test_optimizer32bit). Under the coupled-decay bug this
+        # diverges far beyond the error budget; under the correct decoupled decay it holds.
+        assert_most_approx_close(p1, p2.float(), atol=atol, rtol=rtol, max_error_count=15)
+
+        if gtype != torch.float32:
+            # keep 16-bit params from drifting apart across steps (see test_optimizer32bit)
+            p1.data = p1.data.to(p2.dtype).float()
+            p2.copy_(p1.data)
+
+
 @pytest.mark.parametrize("dim1", [1024], ids=id_formatter("dim1"))
 @pytest.mark.parametrize("dim2", [32, 1024, 4097], ids=id_formatter("dim2"))
 @pytest.mark.parametrize("gtype", [torch.float32, torch.float16], ids=describe_dtype)


### PR DESCRIPTION
Fixes #1992.

## Problem

Lion with `weight_decay > 0` applies **coupled (L2)** weight decay, folding decay into the gradient before the `sign()` in the 32-bit optimizer paths. Lion requires **decoupled** (AdamW-style) decay applied to the parameter directly (`p *= 1 - lr*wd`), _outside_ the sign update (Chen et al. 2023).

Coupling decay into the gradient changes the input to `sign()`, so it corrupts the update _direction_, not just its magnitude.

The smoking gun that this is a bug and not a design choice: the CUDA backend is already inconsistent with itself. The **8-bit blockwise** kernel and the **cpu** backend do decoupled decay correctly; only the **32-bit** paths got it wrong.

## Fix

| Backend     | Path                                     | Before    | After             |
| ----------- | ---------------------------------------- | --------- | ----------------- |
| default     | `backends/default/ops.py`                | coupled   | ✅ decoupled      |
| CUDA 32-bit | `csrc/kernels.cu::kOptimizer32bit1State` | coupled   | ✅ decoupled      |
| CUDA 8-bit  | `kOptimizerStatic8bit1State`             | decoupled | (already correct) |
| cpu         | `backends/cpu/ops.py`                    | decoupled | (already correct) |

The CUDA change mirrors the existing 8-bit kernel exactly: exclude `LION` from the coupled gradient fold, and apply `p *= (1 - lr*wd)` in the `LION` branch before the sign update (un-scaled by the `max_unorm` clip, matching the reference).

I verified `kOptimizer32bit1State` is the only 32-bit CUDA site that applies Lion decay: the 2-state kernel is ADAM/ADEMAMIX (already decoupled), and the 1-state precondition kernel only accumulates the update norm for Lion.

## Test

Adds `test_lion32bit_weight_decay` to `tests/test_optim.py`, comparing `bnb.optim.Lion` against the `lion-pytorch` reference with `weight_decay=0.1`. It's parametrized over `get_available_devices()`, so **it exercises the CUDA 32-bit kernel on GPU CI**. The existing `test_optimizer32bit` never caught this because it uses the default `weight_decay=0`, where coupled and decoupled coincide.

Under the bug the params diverge far past the error budget; with the fix they track the reference.

## Notes / scope

- I can run the default-backend + CPU tests locally, but **not** the CUDA kernel, it's unbuildable on Apple Silicon. Relying on GPU CI to validate the 32-bit CUDA path (happy to help debug any failures).
- The **Triton** 1-state kernel (`backends/triton/kernels_optim.py`) carries the same coupled-decay bug, but it's XPU-only with no CI hardware here. Left as a follow-up, happy to open a companion PR if someone can validate on XPU.