### PR TITLE
Enable non-contiguous quantize_4bit tests for the MPS backend

### DIFF
--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -435,8 +435,8 @@ class TestNonContiguousInputs:
     @pytest.mark.parametrize("quant_type", ["fp4", "nf4"])
     @pytest.mark.parametrize("blocksize", [64, 128, 256])
     def test_quantize_4bit_non_contiguous(self, device, dtype, quant_type, blocksize):
-        if device != "cuda":
-            pytest.skip("Non-contiguous fix targets CUDA backend only")
+        if device not in ("cuda", "mps"):
+            pytest.skip("Non-contiguous input handling not implemented for this backend")
 
         # Reproduce issue #1342: non-contiguous tensor from slicing
         A_full = torch.randn(3, 4, 6, 256, dtype=dtype, device=device)
@@ -458,8 +458,8 @@ class TestNonContiguousInputs:
     @pytest.mark.parametrize("blocksize", [64, 128, 256])
     def test_quantize_4bit_roundtrip_non_contiguous(self, device, dtype, quant_type, blocksize):
         """End-to-end test: quantize non-contiguous, dequantize, compare with contiguous path."""
-        if device != "cuda":
-            pytest.skip("Non-contiguous fix targets CUDA backend only")
+        if device not in ("cuda", "mps"):
+            pytest.skip("Non-contiguous input handling not implemented for this backend")
 
         A_full = torch.randn(3, 4, 6, 256, dtype=dtype, device=device)
         A_noncontig = A_full[:, ::2, :, :]


### PR DESCRIPTION
## Summary

The `TestNonContiguousInputs` 4-bit tests (`test_quantize_4bit_non_contiguous` and `test_quantize_4bit_roundtrip_non_contiguous`) were gated to CUDA only when added in #1859, which fixed the raw-pointer bug (#1342, #1690) that affected the CUDA kernels specifically. The MPS backend already handles non-contiguous inputs correctly via its `reshape`/`contiguous` code paths, so this coverage can safely be extended to it.

This change relaxes the skip guard on those two tests to also run on `mps`.

## Verification

Ran locally on Apple Silicon (macOS, MPS). Non-contiguous inputs produce **bit-identical** results to their contiguous equivalents across every parametrization — `fp4`/`nf4`, `fp16`/`bf16`/`fp32`, and blocksizes `64`/`128`/`256`, for both quantize and the quantize→dequantize roundtrip:

```
36 passed  (previously 36 skipped)
```

## Notes

- The blockwise non-contiguous tests already run on MPS and pass; only the two 4-bit tests were CUDA-gated.
- CPU remains skipped intentionally — its blockwise quantize/dequantize path still produces incorrect results on non-contiguous inputs (a separate issue will be filed).
- No CI impact: CI exercises only the `cpu` and `cuda` backends, so these MPS-only tests are skipped there and run only on developer machines with MPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
