### PR TITLE
Handle non-contiguous inputs in CPU blockwise quantize/dequantize

### DIFF
--- a/bitsandbytes/backends/cpu/ops.py
+++ b/bitsandbytes/backends/cpu/ops.py
@@ -37,6 +37,7 @@ if not isinstance(lib, ErrorHandlerMockBNBNativeLibrary):
 
     @register_kernel("bitsandbytes::quantize_blockwise", "cpu")
     def _(A: torch.Tensor, code: torch.Tensor, blocksize: int) -> tuple[torch.Tensor, torch.Tensor]:
+        A = A.contiguous()
         n = A.numel()
         blocks = -(n // -blocksize)
 
@@ -94,6 +95,7 @@ if not isinstance(lib, ErrorHandlerMockBNBNativeLibrary):
     def _(
         A: torch.Tensor, absmax: torch.Tensor, code: torch.Tensor, blocksize: int, dtype: torch.dtype
     ) -> torch.Tensor:
+        A = A.contiguous()
         out = torch.empty_like(A, dtype=dtype)
         if dtype == torch.float32:
             lib.cdequantize_blockwise_cpu_fp32(

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -382,9 +382,6 @@ class TestNonContiguousInputs:
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32], ids=id_formatter("dtype"))
     @pytest.mark.parametrize("blocksize", [64, 128, 256])
     def test_quantize_blockwise_non_contiguous(self, device, dtype, blocksize):
-        if device == "cpu":
-            pytest.skip("Non-contiguous fix targets CUDA backend only")
-
         code = bitsandbytes.functional.create_dynamic_map().to(device)
 
         # Create non-contiguous tensor via slicing
@@ -404,9 +401,6 @@ class TestNonContiguousInputs:
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32], ids=id_formatter("dtype"))
     @pytest.mark.parametrize("blocksize", [64, 128, 256])
     def test_dequantize_blockwise_non_contiguous(self, device, dtype, blocksize):
-        if device == "cpu":
-            pytest.skip("Non-contiguous fix targets CUDA backend only")
-
         code = bitsandbytes.functional.create_dynamic_map().to(device, dtype=torch.float32)
 
         # Quantize a contiguous tensor, then create non-contiguous uint8 via transpose


### PR DESCRIPTION
## Summary

Fixes #1995. The CPU `quantize_blockwise` / `dequantize_blockwise` kernels pass raw pointers (`get_ptr`) to the native library, which assumes contiguous memory. Non-contiguous inputs (e.g. strided slices) were read in physical order and produced **silently incorrect results** — the same bug class as #1342 / #1690, which #1859 fixed for CUDA only.

Per the maintainer's guidance on #1995, this applies the same approach as the CUDA backend: convert the input with `A = A.contiguous()` at kernel entry.

## Changes

- `bitsandbytes/backends/cpu/ops.py`: add `A = A.contiguous()` at the start of the CPU `quantize_blockwise` and `dequantize_blockwise` kernels (in the latter, before `torch.empty_like` so the output is contiguous as well).
- `tests/test_ops.py`: enable the previously CPU-skipped `TestNonContiguousInputs` blockwise tests.

## Verification

Run locally on the CPU backend (with the compiled native library):

- The two enabled blockwise non-contiguous tests now pass — **18 cases** (`fp16`/`bf16`/`fp32` × blocksize `64`/`128`/`256`); these were previously silently incorrect.
- All CPU blockwise tests pass with no regression on the contiguous path (`.contiguous()` is a no-op there): `289 passed, 0 failed`.

Minimal repro before/after:

```python
import torch
import bitsandbytes.functional as F

A = torch.randn(64, 128)
A_nc = A[::2, :]                       # non-contiguous
qn, sn = F.quantize_blockwise(A_nc, blocksize=64)
qc, sc = F.quantize_blockwise(A_nc.contiguous(), blocksize=64)
print(torch.equal(qn, qc))             # before: False, after: True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
