### PR TITLE
ci: bump Linux ROCm support to 7.2.4

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -118,7 +118,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        rocm_version: ["6.2.4", "6.3.4", "6.4.4", "7.0.2", "7.1.1", "7.2.3"]
+        rocm_version: ["6.2.4", "6.3.4", "6.4.4", "7.0.2", "7.1.1", "7.2.4"]
         include:
           - os: windows-2025
             rocm_version: "7.2.1"

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -246,7 +246,7 @@ The currently distributed `bitsandbytes` are built with the following configurat
 | **Linux x86-64**   | 6.4.4    | CDNA: gfx90a, gfx942 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 | **Linux x86-64**   | 7.0.2    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 | **Linux x86-64**   | 7.1.1    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
-| **Linux x86-64**   | 7.2.3    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
+| **Linux x86-64**   | 7.2.4    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 | **Windows x86-64** | 7.2.1    | RDNA: gfx1100, gfx1101, gfx1102, gfx1150, gfx1151, gfx1200, gfx1201
 
 Use `pip` or `uv` to install the latest release:
@@ -257,7 +257,7 @@ pip install bitsandbytes
 
 ### Compile from Source[[rocm-compile]]
 
-bitsandbytes can be compiled from ROCm 6.2 - ROCm 7.2.3. See the `CMakeLists.txt` for additional options.
+bitsandbytes can be compiled from ROCm 6.2 - ROCm 7.2.4. See the `CMakeLists.txt` for additional options.
 
 <hfoptions id="rocm-source">
 <hfoption id="Linux">


### PR DESCRIPTION
Update the Linux ROCm CI matrix and installation docs to the newly released ROCm 7.2.4 patch while keeping Windows pinned to 7.2.1.