### PR TITLE
Deprecate igemm, batched_igemm, check_matmul APIs

### DIFF
--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 import numpy as np
 import torch
 from torch import Tensor
+from typing_extensions import deprecated
 
 from bitsandbytes.utils import pack_dict_to_tensor, unpack_tensor_to_dict
 
@@ -1211,6 +1212,7 @@ def optimizer_update_8bit_blockwise(
     )
 
 
+@deprecated("This function is deprecated and will be removed in a future release.", category=FutureWarning)
 def check_matmul(A, B, out, transposed_A, transposed_B, expected_type=torch.int8):
     if not torch.cuda.is_initialized():
         torch.cuda.init()
@@ -1332,6 +1334,7 @@ def gemv_4bit(
     )
 
 
+@deprecated("This function is deprecated and will be removed in a future release.", category=FutureWarning)
 def igemm(
     A: Tensor,
     B: Tensor,
@@ -1433,6 +1436,7 @@ def igemm(
     return out
 
 
+@deprecated("This function is deprecated and will be removed in a future release.", category=FutureWarning)
 def batched_igemm(
     A: Tensor,
     B: Tensor,


### PR DESCRIPTION
This PR deprecates some of the last operations from `bitsandbytes.functional` that have not been made accelerator-agnostic through the backend dispatch system. These ops are not used internally and unlikely to be used in the wild.

* `igemm`
* `batched_igemm`
* `check_matmul`