### PR TITLE
fix(parametrize): release the dequant cache when forward raises (#2005)

### DIFF
--- a/bitsandbytes/nn/parametrize.py
+++ b/bitsandbytes/nn/parametrize.py
@@ -127,7 +127,9 @@ def replace_parameter_4bit(
 
 
 def _disable_parametrization_cache(module: nn.Module, inputs: tuple[Any, ...], output: Any):
-    P._cache_enabled -= 1
+    # Clamp at zero: with always_call=True this hook can fire without its matching
+    # pre-hook having run, and a negative count would never clear the cache again.
+    P._cache_enabled = max(0, P._cache_enabled - 1)
     if not P._cache_enabled:
         P._cache = {}
 
@@ -149,8 +151,11 @@ def _register_parametrization_hooks(module: nn.Module, param_name: str):
     # Register hooks to enable caching for the dequantization parametrization.
     # This helps preserve time and memory when the same quantized parameter
     # is accessed multiple times in the forward computation.
+    # always_call so that an exception escaping forward -- notably the
+    # _StopRecomputationError non-reentrant checkpointing raises to early-stop
+    # recomputation -- cannot leave the cache enabled and its tensors pinned.
     module.register_forward_pre_hook(_enable_parametrization_cache)
-    module.register_forward_hook(_disable_parametrization_cache)
+    module.register_forward_hook(_disable_parametrization_cache, always_call=True)
 
 
 def _parametrized_state_dict_post_hook(

--- a/tests/test_parametrize.py
+++ b/tests/test_parametrize.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 import torch.nn as nn
+import torch.nn.utils.parametrize as P
 
 from bitsandbytes import functional as F
 from bitsandbytes.nn.parametrize import (
@@ -431,3 +432,30 @@ def test_gradient_behavior(device, dtype):
     # The dequantized output should also not require gradients
     reconstructed = module.weight_2d
     assert not reconstructed.requires_grad, "Dequantized parameter should not require gradients"
+
+
+def test_cache_released_when_forward_raises():
+    """The cache must be released even when the module's forward raises.
+
+    Non-reentrant activation checkpointing early-stops recomputation by raising
+    through the module's forward, which would otherwise leave the cache enabled
+    and pin every dequantized weight for the rest of the process.
+    """
+
+    class RaisingModule(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = nn.Parameter(torch.randn(64, 64, dtype=torch.float32))
+
+        def forward(self, x):
+            _ = self.weight  # populate the cache, then unwind before the post-hook
+            raise RuntimeError("boom")
+
+    module = RaisingModule()
+    replace_parameter_4bit(module, "weight", quant_type="nf4")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        module(torch.randn(1, 64))
+
+    assert P._cache_enabled == 0, "Cache should be disabled again after forward raises"
+    assert not P._cache, "Dequantized weights should not stay pinned after forward raises"


### PR DESCRIPTION
Fixes #2005.

### Problem

`_register_parametrization_hooks` manages the global parametrization cache with a pre-hook / post-hook pair:

```python
module.register_forward_pre_hook(_enable_parametrization_cache)   # P._cache_enabled += 1
module.register_forward_hook(_disable_parametrization_cache)      # P._cache_enabled -= 1
```

PyTorch does not run regular forward post-hooks when the module's `forward` raises. So if an exception unwinds out of `forward`, `P._cache_enabled` stays `>= 1` forever and `P._cache` is never cleared again — every subsequent forward pins its dequantized weights for the rest of the process.

This is reachable in ordinary use, not just on error paths: non-reentrant `torch.utils.checkpoint` implements early-stopping of recomputation by *raising* `_StopRecomputationError` from a saved-tensor pack hook, straight through the module's `forward`. So `replace_parameter_4bit` + HF `gradient_checkpointing_enable()` — the natural pairing for 4-bit training of fused-MoE experts on small GPUs (see #1849) — leaks memory every step until OOM.

### Fix

1. Register the post-hook with `always_call=True`, so it still runs when `forward` raises. This is available since torch 2.1 and the project already requires `torch>=2.4`, so no version guard is needed.
2. Clamp the counter at zero. `always_call=True` hooks can fire even when the matching pre-hook never ran (e.g. an earlier pre-hook raised); a negative counter would make `if not P._cache_enabled` false forever and pin the cache just the same.

### Verification

Confirmed the underlying hook semantics on torch 2.5.1 — when `forward` raises, the pre-hook runs, a plain post-hook does **not**, and an `always_call=True` post-hook does.

Added `test_cache_released_when_forward_raises`, which drives a parametrized module whose `forward` raises after touching the weight, and asserts the cache is released. It reproduces the bug:

- **without** this fix: `AssertionError: assert 1 == 0` (`P._cache_enabled` stuck at 1, one tensor pinned)
- **with** this fix: passes

Full `tests/test_parametrize.py` suite passes locally (159 passed, CPU + CUDA), and `ruff check` / `ruff format` are clean with the pinned v0.14.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
