### PR TITLE
ci: add ROCm 7.14 support and support more architectures, drop ROCm 6.2 and 6.3 

### DIFF
--- a/.github/scripts/build-rocm.sh
+++ b/.github/scripts/build-rocm.sh
@@ -4,16 +4,48 @@ set -xeuo pipefail
 : "${RUNNER_OS:?RUNNER_OS must be set (Linux/Windows)}"
 : "${ROCM_VERSION:?ROCM_VERSION must be set}"
 
+rocm_version_at_least() {
+    local required_version="$1"
+    local current_major current_minor required_major required_minor
+
+    IFS=. read -r current_major current_minor _ <<< "${ROCM_VERSION}"
+    IFS=. read -r required_major required_minor _ <<< "${required_version}"
+
+    if ((current_major > required_major)); then
+        return 0
+    fi
+    if ((current_major < required_major)); then
+        return 1
+    fi
+    if ((current_minor >= required_minor)); then
+        return 0
+    fi
+    return 1
+}
+
 bnb_rocm_arch="gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1103"
 
 # ROCm 6.4+ - Add RDNA4 and RDNA3.5 targets. Note we assume >=6.4.4.
-[[ "${ROCM_VERSION}" == 6.4.* || "${ROCM_VERSION}" == 7.* ]] && bnb_rocm_arch="${bnb_rocm_arch};gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201"
+if rocm_version_at_least "6.4"; then
+    bnb_rocm_arch="${bnb_rocm_arch};gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201"
+fi
 
 # ROCm 7.0+ - Add gfx950
-[[ "${ROCM_VERSION}" == 7.* ]] && bnb_rocm_arch="${bnb_rocm_arch};gfx950"
+if rocm_version_at_least "7.0"; then
+    bnb_rocm_arch="${bnb_rocm_arch};gfx950"
+fi
+
+# ROCm 7.14+ - Add CDNA1 and RDNA2 targets.
+if rocm_version_at_least "7.14"; then
+    bnb_rocm_arch="${bnb_rocm_arch};gfx908;gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036"
+fi
 
 if [ "${RUNNER_OS}" == "Linux" ]; then
-    image=rocm/dev-ubuntu-22.04:${ROCM_VERSION}-complete
+    image_suffix="complete"
+    if rocm_version_at_least "7.14"; then
+        image_suffix="full"
+    fi
+    image=rocm/dev-ubuntu-22.04:${ROCM_VERSION}-${image_suffix}
     echo "Using image $image"
     docker run --rm -i \
         -w /src -v "$PWD:/src" "$image" sh -c \
@@ -23,15 +55,23 @@ if [ "${RUNNER_OS}" == "Linux" ]; then
 else
     bnb_rocm_arch="gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201"
 
-    # Install ROCm SDK wheels from repo.radeon.com.
-    rocm_base_url="https://repo.radeon.com/rocm/windows/rocm-rel-${ROCM_VERSION}"
-    pip install \
-        "${rocm_base_url}/rocm_sdk_core-${ROCM_VERSION}-py3-none-win_amd64.whl" \
-        "${rocm_base_url}/rocm_sdk_devel-${ROCM_VERSION}-py3-none-win_amd64.whl" \
-        "${rocm_base_url}/rocm_sdk_libraries_custom-${ROCM_VERSION}-py3-none-win_amd64.whl" \
-        "${rocm_base_url}/rocm-${ROCM_VERSION}.tar.gz"
+    if rocm_version_at_least "7.14"; then
+        # Add RDNA2 and additional RDNA3.5 targets.
+        bnb_rocm_arch="${bnb_rocm_arch};gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036;gfx1152;gfx1153"
 
-    # Expand the devel tarball
+        pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "rocm[libraries,devel]==${ROCM_VERSION}"
+    else
+        # Install ROCm SDK wheels from repo.radeon.com.
+        rocm_base_url="https://repo.radeon.com/rocm/windows/rocm-rel-${ROCM_VERSION}"
+        pip install \
+            "${rocm_base_url}/rocm_sdk_core-${ROCM_VERSION}-py3-none-win_amd64.whl" \
+            "${rocm_base_url}/rocm_sdk_devel-${ROCM_VERSION}-py3-none-win_amd64.whl" \
+            "${rocm_base_url}/rocm_sdk_libraries_custom-${ROCM_VERSION}-py3-none-win_amd64.whl" \
+            "${rocm_base_url}/rocm-${ROCM_VERSION}.tar.gz"
+
+    fi
+
+    # Expand the devel tarball.
     rocm-sdk init
 
     ROCM_PATH="$(rocm-sdk path --root | tr '\\' '/')"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -118,10 +118,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        rocm_version: ["6.2.4", "6.3.4", "6.4.4", "7.0.2", "7.1.1", "7.2.4"]
+        rocm_version: ["6.4.4", "7.0.2", "7.1.1", "7.2.4", "7.14.0"]
         include:
           - os: windows-2025
             rocm_version: "7.2.1"
+          - os: windows-2025
+            rocm_version: "7.14.0"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -241,13 +241,13 @@ The currently distributed `bitsandbytes` are built with the following configurat
 
 | **OS**             | **ROCm** | **Targets**
 |--------------------|----------|---------------------------------------------------------------------|
-| **Linux x86-64**   | 6.2.4    | CDNA: gfx90a, gfx942 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103
-| **Linux x86-64**   | 6.3.4    | CDNA: gfx90a, gfx942 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103
 | **Linux x86-64**   | 6.4.4    | CDNA: gfx90a, gfx942 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 | **Linux x86-64**   | 7.0.2    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 | **Linux x86-64**   | 7.1.1    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 | **Linux x86-64**   | 7.2.4    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
+| **Linux x86-64**   | 7.14.0   | CDNA: gfx908, gfx90a, gfx942, gfx950 / RDNA: gfx1030, gfx1031, gfx1032, gfx1033, gfx1034, gfx1035, gfx1036, gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 | **Windows x86-64** | 7.2.1    | RDNA: gfx1100, gfx1101, gfx1102, gfx1150, gfx1151, gfx1200, gfx1201
+| **Windows x86-64** | 7.14.0   | RDNA: gfx1030, gfx1031, gfx1032, gfx1033, gfx1034, gfx1035, gfx1036, gfx1100, gfx1101, gfx1102, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 
 Use `pip` or `uv` to install the latest release:
 
@@ -257,14 +257,14 @@ pip install bitsandbytes
 
 ### Compile from Source[[rocm-compile]]
 
-bitsandbytes can be compiled from ROCm 6.2 - ROCm 7.2.4. See the `CMakeLists.txt` for additional options.
+bitsandbytes can be compiled from ROCm 6.4 - ROCm 7.14.0. See the `CMakeLists.txt` for additional options.
 
 <hfoptions id="rocm-source">
 <hfoption id="Linux">
 
 To compile from source, you need CMake >= **3.31.6** and Python >= **3.10** installed. Make sure you have a compiler installed to compile C++ (`gcc`, `make`, headers, etc.).
 
-You should also have a ROCm installation (system-wide or via Docker). The current minimum supported version is **6.2**.
+You should also have a ROCm installation (system-wide or via Docker). The current minimum supported version is **6.4**.
 
 ```bash
 # Install bitsandbytes from source
@@ -284,10 +284,33 @@ pip install -e .   # `-e` for "editable" install, when developing BNB (otherwise
 
 Compilation on Windows requires Visual Studio 2022 with C++ support, CMake, Ninja, and Python >= **3.10**.
 
-Instead of a system-wide ROCm installation, you can use the pip-installable ROCm SDK wheels from [repo.radeon.com](https://repo.radeon.com/rocm/windows/):
+Instead of a system-wide ROCm installation, use the pip-installable ROCm SDK.
+
+For ROCm 7.14.0, install the current multi-architecture SDK from [repo.amd.com](https://repo.amd.com/rocm/whl-multi-arch/):
 
 ```bash
-# Install ROCm SDK wheels (adjust version as needed)
+pip install ninja cmake
+# Replace gfx1100 with your GPU architecture. To support multiple GPU
+# architectures, add multiple device extras (for example, device-gfx1100,device-gfx1151).
+pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ \
+    "rocm[libraries,devel,device-gfx1100]==7.14.0"
+
+# Expand the devel tarball and link the installed device files.
+rocm-sdk init
+
+# Set ROCM_PATH and activate Visual Studio environment, then build
+export ROCM_PATH="$(rocm-sdk path --root)"
+export PATH="${ROCM_PATH}/bin:${PATH}"
+git clone https://github.com/bitsandbytes-foundation/bitsandbytes.git && cd bitsandbytes/
+# Use the same GPU architecture selected above. Separate multiple architectures with semicolons.
+cmake -G Ninja -DCOMPUTE_BACKEND=hip -DBNB_ROCM_ARCH="gfx1100" -DCMAKE_BUILD_TYPE=Release -DCMAKE_HIP_COMPILER_ROCM_ROOT="${ROCM_PATH}" -S .
+cmake --build . --config Release
+pip install .
+```
+
+For the legacy ROCm 7.2.1 SDK, use the direct wheels from [repo.radeon.com](https://repo.radeon.com/rocm/windows/):
+
+```bash
 pip install ninja cmake
 pip install \
     https://repo.radeon.com/rocm/windows/rocm-rel-7.2.1/rocm_sdk_core-7.2.1-py3-none-win_amd64.whl \


### PR DESCRIPTION
## Summary

- Add ROCm 7.14.0 to the Linux and Windows CI build matrix.
- Use the official rocm/dev-ubuntu-22.04:7.14.0-full image for Linux builds.
- Install the Windows 7.14 development toolchain from AMD's TheRock multi-architecture package index.
- Preserve the legacy repo.radeon.com installation path for Windows ROCm 7.2.1.
- Add ROCm 7.14 architecture coverage:
  - Linux: gfx908 and gfx1030-gfx1036
  - Windows: gfx1030-gfx1036 and gfx1152, gfx1153
- Introduce reusable version-threshold checks so future ROCm releases inherit architecture and packaging changes correctly.
- Drop ROCm 6.2 and 6.3 builds, making ROCm 6.4 the minimum supported version.
- Update the installation guide with the new supported versions, targets, and Windows source-build instructions.