### PR TITLE
CI: Test with torch 2.13

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -72,7 +72,7 @@ jobs:
                 esac
               fi
               ;;
-            linux-aarch64) TEST_RUNNER="ubuntu-22.04-arm" ;;
+            linux-aarch64) TEST_RUNNER="ubuntu-24.04-arm" ;;
             macos)         TEST_RUNNER="macos-15" ;;
             windows)
               [[ "${{ inputs.backend }}" == "cuda" ]] && TEST_RUNNER="CUDA-Windows-x64" || TEST_RUNNER="windows-2025"

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -20,7 +20,7 @@ jobs:
         platform: [linux-x64, linux-aarch64, macos, windows, windows-arm64]
         # default runners don't have AVX-512 support, but icelake does
         cpu_type: ["", icelake]
-        torch_version: ["2.4.1", "2.12.1", "2.13.0", "nightly"]
+        torch_version: ["2.4.1", "2.12.0", "2.13.0", "nightly"]
 
         exclude:
           # aarch64 minimum torch version is 2.5.1
@@ -74,7 +74,7 @@ jobs:
             torch_version: "2.4.1"
             pypi_index: "https://download.pytorch.org/whl/cu118"
           - cuda_version: "12.6.3"
-            torch_version: "2.12.1"
+            torch_version: "2.12.0"
             pypi_index: "https://download.pytorch.org/whl/cu126"
           - cuda_version: "12.8.1"
             torch_version: "2.11.0"

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -20,7 +20,7 @@ jobs:
         platform: [linux-x64, linux-aarch64, macos, windows, windows-arm64]
         # default runners don't have AVX-512 support, but icelake does
         cpu_type: ["", icelake]
-        torch_version: ["2.4.1", "2.12.0", "nightly"]
+        torch_version: ["2.4.1", "2.12.1", "2.13.0", "nightly"]
 
         exclude:
           # aarch64 minimum torch version is 2.5.1
@@ -54,7 +54,7 @@ jobs:
       platform: ${{ matrix.platform }}
       backend: cpu
       torch_version: ${{ matrix.torch_version }}
-      pypi_index: "https://download.pytorch.org/whl/cpu"
+      pypi_index: ${{ matrix.torch_version == 'nightly' && 'https://download.pytorch.org/whl/nightly/cpu' || 'https://download.pytorch.org/whl/cpu' }}
       cpu_type: ${{ matrix.cpu_type }}
 
   test-cuda:
@@ -74,13 +74,13 @@ jobs:
             torch_version: "2.4.1"
             pypi_index: "https://download.pytorch.org/whl/cu118"
           - cuda_version: "12.6.3"
-            torch_version: "2.11.0"
+            torch_version: "2.12.1"
             pypi_index: "https://download.pytorch.org/whl/cu126"
           - cuda_version: "12.8.1"
-            torch_version: "2.10.0"
+            torch_version: "2.11.0"
             pypi_index: "https://download.pytorch.org/whl/cu128"
           - cuda_version: "13.0.2"
-            torch_version: "2.12.0"
+            torch_version: "2.13.0"
             pypi_index: "https://download.pytorch.org/whl/cu130"
           - cuda_version: "13.2.0"
             torch_version: "nightly"

--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -45,7 +45,7 @@ jobs:
           # icelake doesn't apply to windows-arm64
           - platform: windows-arm64
             cpu_type: icelake
-          # Windows ARM64 minimum torch version is 2.12.0
+          # windows-arm64 minimum torch version is 2.7.0
           - platform: windows-arm64
             torch_version: "2.4.1"
 
@@ -79,7 +79,7 @@ jobs:
             torch_version: "2.4.1"
             pypi_index: "https://download.pytorch.org/whl/cu118"
           - cuda_version: "12.6.3"
-            torch_version: "2.12.1"
+            torch_version: "2.12.0"
             pypi_index: "https://download.pytorch.org/whl/cu126"
           - cuda_version: "13.0.2"
             torch_version: "2.13.0"

--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -31,7 +31,7 @@ jobs:
         platform: [linux-x64, linux-aarch64, macos, windows-arm64]
         # default runners don't have AVX-512 support, but icelake does
         cpu_type: ["", icelake]
-        torch_version: ["2.4.1", "2.12.0"]
+        torch_version: ["2.4.1", "2.13.0"]
 
         exclude:
           # aarch64 minimum torch version is 2.5.1
@@ -79,10 +79,10 @@ jobs:
             torch_version: "2.4.1"
             pypi_index: "https://download.pytorch.org/whl/cu118"
           - cuda_version: "12.6.3"
-            torch_version: "2.11.0"
+            torch_version: "2.12.1"
             pypi_index: "https://download.pytorch.org/whl/cu126"
           - cuda_version: "13.0.2"
-            torch_version: "2.12.0"
+            torch_version: "2.13.0"
             pypi_index: "https://download.pytorch.org/whl/cu130"
 
           # Windows CUDA test - single configuration


### PR DESCRIPTION
* Updates nightly and PR test workflows to explicitly include torch 2.13.0
* Drops torch 2.10 configuration from nightly and PR CUDA workflows
* Runs aarch64 Linux CPU tests on ubuntu-24.04 instead of ubuntu-22.04
  * https://github.com/pytorch/pytorch/pull/184555 enables compile flags incompatible with gcc 11 for armv9, causing some of our torch 2.13 tests using `torch.compile` to fail
  * The ubuntu-22.04 runner is scheduled to be deprecated later this year anyway