### PR TITLE
(docs) update XPU section

### DIFF
--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -137,9 +137,9 @@ This is the most straightforward and recommended installation option.
 The currently distributed `bitsandbytes` packages are built with the following configurations:
 
 | **OS**             | **oneAPI Toolkit** | **Kernel Implementation** |
-|--------------------|------------------|----------------------|
-| **Linux x86-64**   | 2025.1.3         | SYCL + Triton        |
-| **Windows x86-64** | 2025.1.3         | SYCL + Triton        |
+|--------------------|--------------------|----------------------|
+| **Linux x86-64**   | 2025.1.3, 2026.0.0 | SYCL + Triton        |
+| **Windows x86-64** | 2025.1.3, 2026.0.0 | SYCL + Triton        |
 
 The Linux build has a minimum glibc version of 2.34.
 


### PR DESCRIPTION
Updates the XPU section of the docs to reflect that we now build with oneAPI 2025 and oneAPI 2026 after #2002.