### PR TITLE
Run `replace_linear`'s `post_processing_function` on the replacement module

### DIFF
--- a/bitsandbytes/utils.py
+++ b/bitsandbytes/utils.py
@@ -157,9 +157,13 @@ def replace_linear(
                 model._modules[name].bias = old_module.bias
 
             if post_processing_function is not None:
-                func = getattr(module, post_processing_function, None)
+                # Look the hook up on the replacement, not on the module we just swapped out: the
+                # original is a plain `nn.Linear` and never carries it, so `getattr(..., None)`
+                # returned None and the hook silently never ran. It is already bound to the new
+                # instance, so it takes no argument.
+                func = getattr(model._modules[name], post_processing_function, None)
                 if func is not None:
-                    func(module)
+                    func()
     return model
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,66 @@
+import torch
+from torch import nn
+
+from bitsandbytes.utils import replace_linear
+
+
+class _TrackingLinear(nn.Linear):
+    """Stands in for a quantized replacement that needs a step after construction."""
+
+    post_init_calls: list[str] = []
+
+    def post_init(self):
+        _TrackingLinear.post_init_calls.append(f"{self.in_features}x{self.out_features}")
+
+
+class _Model(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(4, 8)
+        self.block = nn.Sequential(nn.Linear(8, 16), nn.ReLU())
+        self.lm_head = nn.Linear(16, 4)
+
+
+def test_replace_linear_runs_the_post_processing_hook():
+    """`post_processing_function` is documented as a method of the replacement class.
+
+    It used to be looked up on the module being replaced, which is a plain `nn.Linear` and never
+    carries it, so `getattr(..., None)` returned `None` and the hook silently never ran.
+    """
+    _TrackingLinear.post_init_calls.clear()
+    model = _Model()
+
+    replace_linear(model, _TrackingLinear, post_processing_function="post_init")
+
+    assert isinstance(model.fc, _TrackingLinear)
+    assert isinstance(model.block[0], _TrackingLinear)
+    assert not isinstance(model.lm_head, _TrackingLinear)  # skip_modules default
+    assert _TrackingLinear.post_init_calls == ["4x8", "8x16"]
+
+
+def test_replace_linear_without_hook_is_unchanged():
+    _TrackingLinear.post_init_calls.clear()
+    model = _Model()
+
+    replace_linear(model, _TrackingLinear)
+
+    assert isinstance(model.fc, _TrackingLinear)
+    assert _TrackingLinear.post_init_calls == []
+
+
+def test_replace_linear_tolerates_a_replacement_without_the_hook():
+    """A replacement class that does not define the method must not raise."""
+    model = _Model()
+
+    replace_linear(model, nn.Linear, post_processing_function="post_init")
+
+    assert isinstance(model.fc, nn.Linear)
+
+
+def test_replace_linear_copy_weights():
+    model = _Model()
+    original = model.fc.weight.detach().clone()
+
+    replace_linear(model, _TrackingLinear, copy_weights=True)
+
+    assert torch.equal(model.fc.weight.detach(), original)


### PR DESCRIPTION
`post_processing_function` is documented as

> A function name of the replacement linear class that is called after processing.

but the lookup targets the module being replaced:

```python
if post_processing_function is not None:
    func = getattr(module, post_processing_function, None)
    if func is not None:
        func(module)
```

`module` there is still the original `torch.nn.Linear`. It never carries the hook, so `getattr(..., None)` returns `None` and the block does nothing:

```python
replace_linear(model, MyLinear, post_processing_function="post_init")
# fc replaced with MyLinear, post_init calls: []
```

The parameter is a no-op for every caller, and silently so — the replacement itself works, only the hook is skipped.

Two problems in those three lines: the wrong object, and `func(module)` passing an extra positional argument to what `getattr` has already bound.

## The change

Look the hook up on `model._modules[name]` (the instance just constructed) and call it with no argument.

After:

```python
replace_linear(model, MyLinear, post_processing_function="post_init")
# fc and block[0] replaced, post_init calls: ['4x8', '8x16']
# lm_head untouched via skip_modules
```

A replacement class that does not define the method still returns `None` from `getattr` and passes through, so this cannot start raising for existing callers. Nothing in the repo calls `replace_linear` with the hook, so the change is only visible to downstream users, for whom it goes from "silently ignored" to "runs".

## Tests

New `tests/test_utils.py`:

- the hook fires once per replaced module, with `skip_modules` still honoured
- omitting the hook changes nothing
- a replacement class without the method does not raise
- `copy_weights=True` still carries the original weight

Reverting only `bitsandbytes/utils.py`:

```
tests/test_utils.py::test_replace_linear_runs_the_post_processing_hook FAILED
1 failed, 3 passed
```

and with the change, `4 passed`. `ruff check` and `ruff format --check` clean.
