### PR TITLE
Give each parameter its own config dict in `override_config`

### DIFF
--- a/bitsandbytes/optim/optimizer.py
+++ b/bitsandbytes/optim/optimizer.py
@@ -108,7 +108,10 @@ class GlobalOptimManager:
                 if id(p) in self.pid2config:
                     self.pid2config[id(p)].update(key_value_dict)
                 else:
-                    self.pid2config[id(p)] = key_value_dict
+                    # Copy per parameter. Storing the same dict for several parameters means a
+                    # later single-parameter override lands on all of them, and storing a
+                    # caller-supplied `key_value_dict` by reference mutates their dict too.
+                    self.pid2config[id(p)] = dict(key_value_dict)
 
     def register_module_override(self, module, param_name, config):
         self.module_weight_config_triple.append((module, param_name, config))

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -369,6 +369,43 @@ def test_override_config_after_register(device):
     assert adam.state[p2]["state1"].dtype == torch.uint8
 
 
+def test_override_config_does_not_share_one_dict_across_parameters():
+    """A per-parameter override must not land on the other parameters of the same call.
+
+    Parameters that had no config yet were all assigned the same dict object, so a later
+    `override_config(p1, ...)` took the update branch and mutated the config every one of them
+    was pointing at.
+    """
+    mng = bnb.optim.GlobalOptimManager.get_instance()
+    mng.initialize()
+
+    p1 = torch.nn.Parameter(torch.zeros(2))
+    p2 = torch.nn.Parameter(torch.zeros(2))
+
+    mng.override_config([p1, p2], "optim_bits", 32)
+    assert mng.pid2config[id(p1)] is not mng.pid2config[id(p2)]
+
+    mng.override_config(p1, "lr", 0.01)
+
+    assert mng.pid2config[id(p1)] == {"optim_bits": 32, "lr": 0.01}
+    assert mng.pid2config[id(p2)] == {"optim_bits": 32}
+
+
+def test_override_config_does_not_mutate_the_callers_dict():
+    """A `key_value_dict` passed in by the caller is theirs, not the manager's to extend."""
+    mng = bnb.optim.GlobalOptimManager.get_instance()
+    mng.initialize()
+
+    p = torch.nn.Parameter(torch.zeros(2))
+    config = {"optim_bits": 8}
+
+    mng.override_config(p, key_value_dict=config)
+    mng.override_config(p, "lr", 0.5)
+
+    assert config == {"optim_bits": 8}
+    assert mng.pid2config[id(p)] == {"optim_bits": 8, "lr": 0.5}
+
+
 optimizer_names_8bit = [
     "adam8bit_blockwise",
     "lion8bit_blockwise",


### PR DESCRIPTION
`override_config` stores the same dict object for every parameter that does not already have an entry:

```python
if id(p) in self.pid2config:
    self.pid2config[id(p)].update(key_value_dict)
else:
    self.pid2config[id(p)] = key_value_dict
```

So a later single-parameter override takes the `update` branch and writes into the config every parameter from the earlier call is pointing at:

```python
mng.override_config([p1, p2], "optim_bits", 32)
mng.pid2config[id(p1)] is mng.pid2config[id(p2)]   # True

mng.override_config(p1, "lr", 0.01)
# p1: {'optim_bits': 32, 'lr': 0.01}
# p2: {'optim_bits': 32, 'lr': 0.01}   <- never asked for
```

The docstring's own example is exactly this shape — register several parameters, then override one of them — so it is the documented usage rather than an edge case. Nothing raises; the affected parameters just train with hyperparameters the caller did not choose.

The same reference is handed back out when the caller passes `key_value_dict` themselves, so their dictionary grows behind their back:

```python
d = {"optim_bits": 8}
mng.override_config(p3, key_value_dict=d)
mng.override_config(p3, "lr", 0.5)
# d -> {'optim_bits': 8, 'lr': 0.5}
```

## The change

Copy on insert (`dict(key_value_dict)`). After:

```
p1: {'optim_bits': 32, 'lr': 0.01}
p2: {'optim_bits': 32}
d : {'optim_bits': 8}
```

The `update` branch is unchanged, so accumulating several overrides onto one parameter still works the way it does today.

## Tests

Two added next to `test_override_config_after_register` in `tests/test_optim.py`, both CPU-only:

- `test_override_config_does_not_share_one_dict_across_parameters` — asserts the two configs are distinct objects and that overriding `p1` leaves `p2` alone
- `test_override_config_does_not_mutate_the_callers_dict` — asserts the caller's dict is unchanged while the stored config still accumulates

Reverting only `optimizer.py`:

```
tests/test_optim.py::test_override_config_does_not_share_one_dict_across_parameters FAILED
tests/test_optim.py::test_override_config_does_not_mutate_the_callers_dict FAILED
2 failed
```

and with the change, `2 passed`. `ruff check` and `ruff format --check` clean.

Separate from #2028, which is in `utils.py`; no overlapping hunks.
