### PR TITLE
Add sm121 (GB10) tier to the 4-bit GEMM dispatch heuristic
  

### DIFF
--- a/bitsandbytes/backends/cuda/ops.py
+++ b/bitsandbytes/backends/cuda/ops.py
@@ -592,6 +592,10 @@ def _gemm_4bit_use_custom_cuda(device_index, dtype, M, N, K):
       sm90 (H100/H200, HBM3/HBM3e):  dequant+linear is much faster; thresholds are tight.
       sm100 (B200/B300, HBM3e):       exits early at top of function.
       sm120 (RTX 5000, GDDR7):        dedicated block; medium-N tiers differ from sm89.
+      sm121 (GB10 DGX Spark, LPDDR5X):  dedicated block at >=1 wave only; the low
+                                     memory bandwidth keeps the custom kernel ahead
+                                     through M=256 there. Sub-wave shapes use the
+                                     sm89 tiers below.
     """
     if M <= _GEMM_4BIT_CUSTOM_FLOOR_M:
         return True
@@ -623,6 +627,7 @@ def _gemm_4bit_use_custom_cuda(device_index, dtype, M, N, K):
     is_sm86 = major == 8 and minor == 6
     is_sm90 = major == 9
     is_sm120 = major == 12 and minor == 0
+    is_sm121 = major == 12 and minor == 1
     is_hbm = is_sm80 or is_sm90  # sm100 already returned above
     tall_k_2xn = K > N * 2
 
@@ -753,10 +758,17 @@ def _gemm_4bit_use_custom_cuda(device_index, dtype, M, N, K):
             return M <= 16
         return False
 
+    if is_sm121:
+        # GB10 (DGX Spark): unified LPDDR5X, far less bandwidth than the sm89 GDDR6X
+        # parts this used to fall through to, so dequant+F.linear stays expensive
+        # much further up the M range. Calibrated on GB10 at >=1 wave only; below
+        # one wave the crossover is strongly K-dependent, so those shapes keep using
+        # the shared tiers below (which already branch on tall-K).
+        if n_blocks >= num_sms:
+            return M <= 256
+
     if is_sm120:
         # GDDR7 (~1-1.8 TB/s). Medium-N threshold tiers differ from sm89.
-        # sm121 (DGX Spark) has a different bandwidth/SM profile; uses sm89
-        # fallback below until validated.
         if n_blocks >= num_sms * 3:
             return M <= 256
         if n_blocks >= num_sms * 2:
@@ -773,7 +785,7 @@ def _gemm_4bit_use_custom_cuda(device_index, dtype, M, N, K):
             return M <= 16
         return M <= 8
 
-    # Fallback: sm89 (4090, L40S, L4), sm121 (DGX Spark), unrecognized arches.
+    # Fallback: sm89 (4090, L40S, L4), sm121 below one wave, unrecognized arches.
     # GDDR bandwidth makes dequant relatively expensive so custom wins at higher M.
     if n_blocks >= num_sms * 3:
         return M <= 256

--- a/bitsandbytes/backends/cuda/ops.py
+++ b/bitsandbytes/backends/cuda/ops.py
@@ -759,11 +759,9 @@ def _gemm_4bit_use_custom_cuda(device_index, dtype, M, N, K):
         return False
 
     if is_sm121:
-        # GB10 (DGX Spark): unified LPDDR5X, far less bandwidth than the sm89 GDDR6X
-        # parts this used to fall through to, so dequant+F.linear stays expensive
-        # much further up the M range. Calibrated on GB10 at >=1 wave only; below
-        # one wave the crossover is strongly K-dependent, so those shapes keep using
-        # the shared tiers below (which already branch on tall-K).
+        # GB10 (DGX Spark): unified LPDDR5X. Calibrated at >=1 wave only; below one
+        # wave the crossover is strongly K-dependent, so those shapes use the shared
+        # tiers below (which already branch on tall-K).
         if n_blocks >= num_sms:
             return M <= 256
 


### PR DESCRIPTION
## What this does

Adds an `sm121` branch to `_gemm_4bit_use_custom_cuda` so GB10 (DGX Spark) stops falling through to the sm89 tiers, and updates the two comments that say sm121 is unvalidated.

Right now sm121 is explicitly routed to the sm89 fallback with a comment saying "uses sm89 fallback below until validated". This is that validation, for the part of the space I could measure reliably.

## Why sm121 needs its own tier

GB10 is unified LPDDR5X, so it has far less bandwidth than the GDDR6X parts sm89 was calibrated on. Dequant plus `F.linear` stays expensive much further up the M range, which means the custom kernel keeps winning past the sm89 caps.

The change is one branch:

```python
if is_sm121:
    if n_blocks >= num_sms:
        return M <= 256
```

Everything below one wave keeps using the shared tiers, because there the crossover is strongly K-dependent and I did not have clean enough data to justify a separate rule.

## Safety

This cannot change behaviour on any other architecture, and that is checkable rather than argued. I enumerated the dispatch decisions of the stock and patched functions over a cross product of 10 architecture profiles (sm75/sm80/sm86/sm89/sm90/sm100/sm120/sm121 plus an unrecognized arch), 3 dtypes, and 23 x 11 x 8 M x N x K shapes:

```
60,720 decisions enumerated
    216 changed
    216 False -> True
      0 True  -> False
```

All 216 changes land on the sm121 profile, at M between 48 and 256. No other arch is touched anywhere in the grid. Since it is exhaustive over the enumerated space rather than sampled, it is a proof of no-regression for those shapes, not evidence of one.

## Tests

Run against the released 0.50.0 wheel with only this function transplanted, since the source tree ships no compiled library. The function source is byte-identical between the wheel and main (verified by direct comparison), so the substitution is faithful.

| suite | stock | patched |
|---|---|---|
| `test_functional.py -k 4bit` | 1977 passed, 864 skipped | identical |
| `test_linear4bit.py` + `test_autograd.py` | 2156 passed, 1 failed | identical |

The one failure is `test_fsdp_state_dict_save_4bit`, and it fails on stock too, so it is pre-existing on this machine and not caused by this change.

## Honest limits

Three things I want to be upfront about, because they bound what this PR claims.

**The cap is conservative, not exact.** I originally thought M=256 was the crossover. It is not: across five measurement sessions, M=384 still favours the custom kernel on 10 of 14 shapes (cell median about 1.2x) and M=512 on 7 to 8 of 14. Within the at-or-above-one-wave region the only M=384 loser is the smallest tier-A shape, (3072, 3072), at 0.86x to 0.94x across five sessions. So M=256 leaves real headroom, and I chose it deliberately rather than pushing to the measured edge on one shape.

**Only the at-or-above-one-wave region is calibrated.** I had a wider three-tier version of this patch. I threw it away: enumerating it the same way showed it changing decisions at N=2560 in the tall-K shapes, a region where my own measurements do not support a clean rule (the custom kernel swings from about 3x ahead at low M to 0.75x behind at M=384, across four seeds). Two of its three tiers rested on a single measured shape each. This PR is what survived that.

**No real model forward was run.** All timings are synthetic stacks of real projection shapes, not an actual HuggingFace model, and the machine had an unrelated job resident throughout, so absolute microseconds are upper bounds. The dispatch decisions above are exact; the performance motivation behind them is measured but not production-validated.

Environment: GB10 (DGX Spark), sm_121, aarch64, driver 580.142, torch 2.13.0+cu130, CUDA 13.0.

Happy to add a regression test for the dispatch table, or to widen the cap if someone with a second GB10 can confirm the M=384 numbers.
