### PR TITLE
Warn once, and only when it matters, for unaligned gemm_4bit

### DIFF
--- a/bitsandbytes/backends/cuda/ops.py
+++ b/bitsandbytes/backends/cuda/ops.py
@@ -3,7 +3,6 @@ import ctypes as ct
 import functools
 from math import prod
 from typing import Optional
-from warnings import warn
 
 import torch
 
@@ -11,6 +10,7 @@ from bitsandbytes.functional import CUBLAS_Context, _cuda_device_of, get_ptr
 
 from ..._ops import register_kernel
 from ...cextension import lib
+from ..utils import _warn_gemm_4bit_unaligned
 
 
 def _setup_ctypes(names, argtypes, restype=None):
@@ -943,15 +943,13 @@ def _(
     # fallback.
     if M > _gemm_4bit_custom_max_m:
         use_custom = False
-    elif K % blocksize != 0:
-        warn(
-            f"inner dimension ({K}) is not aligned for fast kernel "
-            f"with blocksize={blocksize}, falling back to slower implementation.",
-            UserWarning,
-        )
-        use_custom = False
     else:
         use_custom = _gemm_4bit_use_custom_fn(A.device.index, A.dtype, M, N, K)
+        if use_custom and K % blocksize != 0:
+            # Only warn when misalignment is what costs us the fused kernel; when the
+            # heuristic picks the fallback anyway (larger M, e.g. training), it doesn't.
+            _warn_gemm_4bit_unaligned(K, blocksize)
+            use_custom = False
 
     if not use_custom:
         return _dequant_linear_fallback(

--- a/bitsandbytes/backends/utils.py
+++ b/bitsandbytes/backends/utils.py
@@ -1,4 +1,6 @@
+import functools
 from importlib.metadata import metadata
+from warnings import warn
 
 from packaging import version
 import torch
@@ -73,6 +75,17 @@ def _get_4bit_code(quant_type: str, device: torch.device) -> torch.Tensor:
 
         _code_4bit_cache[key] = get_4bit_type(quant_type, device=device)
     return _code_4bit_cache[key]
+
+
+@functools.cache
+def _warn_gemm_4bit_unaligned(K: int, blocksize: int) -> None:
+    """Warn at most once per (K, blocksize): the misalignment is a fixed property of the
+    model, so repeating it on every gemm_4bit call is pure noise."""
+    warn(
+        f"inner dimension ({K}) is not aligned for fast kernel "
+        f"with blocksize={blocksize}, falling back to slower implementation.",
+        UserWarning,
+    )
 
 
 def get_gaudi_sw_version():

--- a/bitsandbytes/backends/xpu/ops.py
+++ b/bitsandbytes/backends/xpu/ops.py
@@ -2,7 +2,6 @@ from collections.abc import Sequence
 import ctypes as ct
 import logging
 from typing import Optional
-from warnings import warn
 
 from packaging import version
 import torch
@@ -12,7 +11,7 @@ from bitsandbytes.functional import _get_tensor_stream, get_ptr
 from ..._ops import register_kernel
 from ...cextension import ErrorHandlerMockBNBNativeLibrary, lib
 from ..default.ops import _gemm_4bit_default_impl
-from ..utils import _get_4bit_code, triton_available
+from ..utils import _get_4bit_code, _warn_gemm_4bit_unaligned, triton_available
 
 logger = logging.getLogger(__name__)
 
@@ -186,11 +185,7 @@ def _(
                 out = out + bias
             return out
 
-        warn(
-            f"inner dimension ({K}) is not aligned for fast kernel "
-            f"with blocksize={blocksize}, falling back to slower implementation.",
-            UserWarning,
-        )
+        _warn_gemm_4bit_unaligned(K, blocksize)
 
     return _gemm_4bit_default_impl(
         A,

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,4 +1,5 @@
 from math import prod
+import warnings
 
 import pytest
 import torch
@@ -332,6 +333,28 @@ class Test4bitBlockwiseQuantOps:
                 (A_op, B_q, list(B.shape), qs.absmax, blocksize, quant_type),
                 kwargs={"bias": bias},
             )
+
+    @pytest.mark.parametrize("device", get_available_devices())
+    def test_gemm_4bit_unaligned_warning(self, device):
+        """Regression test for #2027: the blocksize-alignment warning must not be emitted
+        on every call, nor at all when the fused kernel was not going to be used anyway."""
+        N, K, blocksize = 128, 3420, 64  # 3420 % 64 != 0 (Qwen2.5-VL vision tower)
+        B = torch.randn(N, K, dtype=torch.float16, device=device)
+        B_q, qs = bitsandbytes.functional.quantize_4bit(B, blocksize=blocksize, quant_type="nf4")
+
+        def run(M):
+            A = torch.randn(M, K, dtype=torch.float16, device=device)
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                for _ in range(2):
+                    torch.ops.bitsandbytes.gemm_4bit.default(A, B_q, list(B.shape), qs.absmax, blocksize, "nf4")
+            return [w for w in caught if "not aligned" in str(w.message)]
+
+        # Large M always takes the dequant+F.linear path, aligned or not.
+        assert run(1024) == []
+
+        # When alignment does decide it, warn at most once per (K, blocksize).
+        assert len(run(1)) <= 1
 
     @pytest.mark.parametrize("device", get_available_devices())
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=describe_dtype)


### PR DESCRIPTION
Fixes #2027

In the CUDA `gemm_4bit` dispatch the `K % blocksize != 0` check sat in an `elif` ahead of the kernel-selection heuristic, so any call with `M <= _gemm_4bit_custom_max_m` (1536) and a misaligned `K` warned, even though the heuristic caps the fused kernel at `M <= 512` and would have taken the `dequant + F.linear` fallback anyway. That is why the warning shows up during training, where `M` is `batch * seq_len`. On top of that it was emitted per call, so a model whose `K` is inherently misaligned (Qwen2.5-VL vision tower, `K = 3420`) got one warning per forward.

Changes:

- `backends/cuda/ops.py`: run the heuristic first and warn only when misalignment is what actually cost us the fused kernel.
- `backends/utils.py`: the warning body moves into a `functools.cache`d `_warn_gemm_4bit_unaligned(K, blocksize)`, so it fires at most once per shape per process.
- `backends/xpu/ops.py`: calls the same helper. The warning text there was a verbatim copy.

No behaviour change beyond the warning. Every call that used to warn took the fallback then and takes it now, so numerics are identical.

Verified on an A40 (sm_86), CUDA 12.6, torch 2.13.0+cu126. With the issue's repro (`K = 3420`, `blocksize = 64`, 10 calls) the counts go from 10/10/10 to 1/0/0 for M=1 inference, batched, and a `Linear4bit` training forward+backward. New test `tests/test_ops.py::Test4bitBlockwiseQuantOps::test_gemm_4bit_unaligned_warning` fails on CUDA before the patch and passes after. `tests/test_ops.py` and the 4-bit subset of `tests/test_functional.py` pass, and the pre-commit hooks pass on the changed files.

Not verified on hardware I do not have: the XPU change (mechanical substitution, no control-flow change) and ROCm, which shares the CUDA dispatch and can only see fewer warnings after this. Arch coverage is sm_86 only. The fix keys on the heuristic's return value rather than any threshold, so it is arch-independent, but the exact `M` at which warnings stop is not.

Thanks to @albertvillanova for the report and the precise diagnosis.