### PR TITLE
fix: missing compilation flag on  recent msvc version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,12 +338,12 @@ if(WIN32)
 endif()
 
 if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast /Zc:preprocessor")
+
     # /arch:AVX2 is only valid for x86/x64 targets, not ARM64
     string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _msvc_arch)
     if(_msvc_arch MATCHES "x86|x64|amd64")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2 /fp:fast")
-    else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,7 +338,13 @@ if(WIN32)
 endif()
 
 if(MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast /Zc:preprocessor")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:fast")
+
+    # Only real cl.exe needs (and accepts) the conformant preprocessor switch;
+    # clang-cl / icx are already conformant and warn on it.
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:preprocessor")
+    endif()
 
     # /arch:AVX2 is only valid for x86/x64 targets, not ARM64
     string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _msvc_arch)


### PR DESCRIPTION
In recent MSVC compiler versions it needs to specify which preprocessor to use. 

This PR addresses this adding the required flag for MSVC.