### PR TITLE
build: Add Windows ARM64 build with CUDA 13.4 for RTX Spark

### DIFF
--- a/.github/scripts/build-cuda.sh
+++ b/.github/scripts/build-cuda.sh
@@ -8,13 +8,17 @@ set -xeuo pipefail
 if [[ -v CUDA_TARGETS ]]; then
     build_capability="${CUDA_TARGETS}"
 elif [ "${RUNNER_ARCH}" = "ARM64" ]; then
-    build_capability="75;80;90"
+    if [ "${RUNNER_OS}" = "Windows" ]; then
+        build_capability="121"
+    else
+        build_capability="75;80;90"
 
-    # CUDA 12.8-12.9: Add sm100/sm120
-    [[ "${CUDA_VERSION}" == 12.8.* || "${CUDA_VERSION}" == 12.9.* ]] && build_capability="75;80;90;100;120"
+        # CUDA 12.8-12.9: Add sm100/sm120
+        [[ "${CUDA_VERSION}" == 12.8.* || "${CUDA_VERSION}" == 12.9.* ]] && build_capability="75;80;90;100;120"
 
-    # CUDA 13.0+: Add sm100/sm110/sm120
-    [[ "${CUDA_VERSION}" == 13.*.* ]] && build_capability="75;80;90;100;110;120;121"
+        # CUDA 13.0+: Add sm100/sm110/sm120
+        [[ "${CUDA_VERSION}" == 13.*.* ]] && build_capability="75;80;90;100;110;120;121"
+    fi
 else
     # By default, target Pascal through Hopper.
     build_capability="60;70;75;80;86;89;90"

--- a/.github/scripts/install-cuda-woa.ps1
+++ b/.github/scripts/install-cuda-woa.ps1
@@ -1,0 +1,27 @@
+# Installs the CUDA 13.4 preview toolkit for Windows arm64.
+$ErrorActionPreference = "Stop"
+
+$url = "https://packages.nvidia.com/prerelease/cuda/13.4.0/local_installers/cuda_13.4.0_windows_arm64.exe"
+$subPackages = @(
+    "nvcc_13.4", "crt_13.4", "nvvm_13.4", "nvptxcompiler_13.4",
+    "cudart_13.4", "cublas_13.4", "cublas_dev_13.4", "thrust_13.4"
+)
+$cudaPath = "$env:ProgramFiles\NVIDIA GPU Computing Toolkit\CUDA\v13.4"
+$installer = Join-Path $env:RUNNER_TEMP "cuda_13.4.0.exe"
+
+Write-Host "Downloading $url"
+curl.exe --fail --location --retry 3 --output $installer $url
+if ($LASTEXITCODE -ne 0) { throw "Failed to download $url" }
+
+Write-Host "Installing subpackages: $($subPackages -join ' ')"
+$proc = Start-Process -FilePath $installer -ArgumentList (@("-s", "-n") + $subPackages) -Wait -PassThru
+Remove-Item $installer -Force
+if ($proc.ExitCode -ne 0) { throw "CUDA installer exited with code $($proc.ExitCode)" }
+
+if (-not (Test-Path "$cudaPath\bin\nvcc.exe")) { throw "nvcc not found under $cudaPath" }
+
+Write-Host "Installed CUDA to $cudaPath"
+& "$cudaPath\bin\nvcc.exe" --version
+
+"CUDA_PATH=$cudaPath" | Out-File $env:GITHUB_ENV -Append
+"$cudaPath\bin" | Out-File $env:GITHUB_PATH -Append

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,12 +60,15 @@ jobs:
         os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2025]
         cuda_version:
           ["11.8.0", "12.1.1", "12.4.1", "12.6.3", "12.8.1", "13.0.2", "13.2.0"]
+        include:
+          - os: windows-11-vs2026-arm
+            cuda_version: "13.4.0"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         # Windows: We install Cuda on the agent (slow)
       - uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && runner.arch == 'X64'
         id: cuda-toolkit
         with:
           cuda: ${{ matrix.cuda_version }}
@@ -75,11 +78,16 @@ jobs:
           use-github-cache: false
           use-local-cache: false
           log-file-suffix: ${{ runner.os }}-${{ runner.arch }}-${{matrix.cuda_version}}.txt
+      - name: Install CUDA Toolkit (WoA)
+        if: runner.os == 'Windows' && runner.arch == 'ARM64'
+        run: ./.github/scripts/install-cuda-woa.ps1
+        shell: pwsh
       - name: Setup MSVC
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
-          toolset: "14.44"
+          arch: ${{ runner.arch == 'ARM64' && 'arm64' || 'x64' }}
+          toolset: ${{ runner.arch == 'X64' && '14.44' || '' }}
       - name: Build C++
         run: bash .github/scripts/build-cuda.sh
         env:

--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ bitsandbytes has the following minimum requirements for all platforms:
       <td>✅</td>
     </tr>
     <tr>
+      <td></td>
+      <td>🟩 NVIDIA GPU <br><code>cuda</code></td>
+      <td>SM121</td>
+      <td>✅</td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
       <td colspan="6">🍎 <strong>macOS 14+</strong></td>
     </tr>
     <tr>

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -53,13 +53,15 @@ The currently distributed `bitsandbytes` packages are built with the following c
 | **OS**             | **CUDA Toolkit** | **Host Compiler**    | **Targets**
 |--------------------|------------------|----------------------|--------------
 | **Linux x86-64**   | 11.8 - 12.6      | GCC 11.2             | sm60, sm70, sm75, sm80, sm86, sm89, sm90
-| **Linux x86-64**   | 12.8 - 12.9      | GCC 11.2             | sm70, sm75, sm80, sm86, sm89, sm90, sm100, sm120
-| **Linux x86-64**   | 13.0             | GCC 11.2             | sm75, sm80, sm86, sm89, sm90, sm100, sm120
+| **Linux x86-64**   | 12.8             | GCC 11.2             | sm70, sm75, sm80, sm86, sm89, sm90, sm100, sm120
+| **Linux x86-64**   | 13.0 - 13.2      | GCC 11.2             | sm75, sm80, sm86, sm89, sm90, sm100, sm120
 | **Linux aarch64**  | 11.8 - 12.6      | GCC 11.2             | sm75, sm80, sm90
-| **Linux aarch64**  | 12.8 - 13.0      | GCC 11.2             | sm75, sm80, sm90, sm100, sm110, sm120, sm121
+| **Linux aarch64**  | 12.8             | GCC 11.2             | sm75, sm80, sm90, sm100, sm120
+| **Linux aarch64**  | 13.0 - 13.2      | GCC 11.2             | sm75, sm80, sm90, sm100, sm110, sm120, sm121
 | **Windows x86-64** | 11.8 - 12.6      | MSVC 19.43+ (VS2022) | sm50, sm60, sm75, sm80, sm86, sm89, sm90
-| **Windows x86-64** | 12.8 - 12.9      | MSVC 19.43+ (VS2022) | sm70, sm75, sm80, sm86, sm89, sm90, sm100, sm120
-| **Windows x86-64** | 13.0             | MSVC 19.43+ (VS2022) | sm75, sm80, sm86, sm89, sm90, sm100, sm120
+| **Windows x86-64** | 12.8             | MSVC 19.43+ (VS2022) | sm70, sm75, sm80, sm86, sm89, sm90, sm100, sm120
+| **Windows x86-64** | 13.0 - 13.2      | MSVC 19.43+ (VS2022) | sm75, sm80, sm86, sm89, sm90, sm100, sm120
+| **Windows arm64**  | 13.4             | MSVC 19.51+ (VS2026) | sm121
 
 The Linux build has a minimum glibc version of 2.24.
 
@@ -129,6 +131,8 @@ pip install -e .   # `-e` for "editable" install, when developing BNB (otherwise
 Compilation from source on Windows systems require Visual Studio with C++ support as well as an installation of the CUDA Toolkit.
 
 To compile from source, you need CMake >= **3.22.1** and Python >= **3.10** installed. You should also install CUDA Toolkit by following the [CUDA Installation Guide for Windows](https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html) guide from NVIDIA. The current minimum supported CUDA Toolkit version that we support is **11.8**.
+
+On Windows ARM64, the CUDA Toolkit is supported from version **13.4**, and Visual Studio must include the **ARM64 C++ build tools** component.
 
 ```bash
 git clone https://github.com/bitsandbytes-foundation/bitsandbytes.git && cd bitsandbytes/
@@ -343,7 +347,7 @@ pip install -e .
 ```
 
 > [!NOTE]
-> The build system will detect the ARM64 architecture automatically via CMake. Only the CPU backend is supported on Windows ARM64 at this time (no CUDA).
+> The build system will detect the ARM64 architecture automatically via CMake. For a CUDA build on Windows ARM64, see [Compile from Source](#cuda-compile) in the CUDA section; CUDA Toolkit 13.4 or newer is required.
 
 </hfoption>
 </hfoptions>


### PR DESCRIPTION
* Adds CUDA build step for Windows on ARM.
  * Uses CUDA Toolkit 13.4 preview release.
  * Specifically only targets sm121 for the RTX Spark.
  * Uses VS2026, while other builds still use VS2022.
* Updates to documentation where appropriate.
