### PR TITLE
Fix decoupled weight decay ordering in the CUDA Adam/AdEMAMix kernels

### DIFF
--- a/csrc/kernels.cu
+++ b/csrc/kernels.cu
@@ -690,11 +690,11 @@ __launch_bounds__(TH, 1) __global__ void kOptimizer32bit2State(
                 // nu update: nu = beta2 * nu + (1-beta2) * g^2
                 s2_vals[j] = (s2_vals[j] * beta2) + ((1.0f - beta2) * (float)g_vals[j] * (float)g_vals[j]);
 
-                p_vals[j] = (float)p_vals[j] - lr * (((s1_vals[j] / correction1) + (alpha * s3_vals[j])) /
-                                                     ((sqrtf(s2_vals[j]) / correction2) + eps));
-
                 if (weight_decay > 0.0f)
                     p_vals[j] = ((float)p_vals[j]) * (1.0f - (lr * weight_decay));
+
+                p_vals[j] = (float)p_vals[j] - lr * (((s1_vals[j] / correction1) + (alpha * s3_vals[j])) /
+                                                     ((sqrtf(s2_vals[j]) / correction2) + eps));
 
                 break;
             case ADAM:
@@ -702,11 +702,12 @@ __launch_bounds__(TH, 1) __global__ void kOptimizer32bit2State(
                 if (!skip_zeros || (skip_zeros && ((float)g_vals[j] != 0.0f))) {
                     s1_vals[j] = s1_vals[j] * beta1 + ((1.0f - beta1) * ((float)g_vals[j]));
                     s2_vals[j] = s2_vals[j] * beta2 + ((1.0f - beta2) * (((float)g_vals[j]) * ((float)g_vals[j])));
-                    p_vals[j] = ((float)p_vals[j]) +
-                                (update_scale * step_size * (s1_vals[j] / (sqrtf(s2_vals[j]) + (eps * correction2))));
 
                     if (weight_decay > 0.0f)
                         p_vals[j] = ((float)p_vals[j]) * (1.0f - (lr * weight_decay));
+
+                    p_vals[j] = ((float)p_vals[j]) +
+                                (update_scale * step_size * (s1_vals[j] / (sqrtf(s2_vals[j]) + (eps * correction2))));
                 }
                 break;
             }
@@ -1090,6 +1091,9 @@ __launch_bounds__(256, 3) __global__ void kOptimizerStatic8bit2StateBlockwise(
         for (unsigned int j = 0; j < N_PER_TH; j++) {
             // if(!skip_zeros || (skip_zeros && ((float)g_vals[j] != 0.0f)))
             if (!isnan((float)g_vals[j]) && !isinf((float)g_vals[j])) {
+                if (weight_decay > 0.0f)
+                    p_vals[j] = ((float)p_vals[j]) * (1.0f - (lr * weight_decay));
+
                 if (OPTIMIZER == ADEMAMIX) {
                     p_vals[j] =
                         T((float)p_vals[j] - lr * (((s1_vals[j] / correction1) + (alpha * s3_vals[j])) /
@@ -1099,9 +1103,6 @@ __launch_bounds__(256, 3) __global__ void kOptimizerStatic8bit2StateBlockwise(
                         (T)(((float)p_vals[j]) +
                             ((step_size * (__fdividef(s1_vals[j], (sqrtf(s2_vals[j]) + (correction2 * eps)))))));
                 }
-
-                if (weight_decay > 0.0f)
-                    p_vals[j] = ((float)p_vals[j]) * (1.0f - (lr * weight_decay));
             }
         }
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -292,6 +292,107 @@ def test_lion32bit_weight_decay(dim1, dim2, gtype, device):
             p2.copy_(p1.data)
 
 
+# Decoupled weight decay multiplies the *previous* parameter and leaves the
+# gradient-based update unscaled: p_new = p_old*(1 - lr*wd) + step_size*update.
+# See Loshchilov & Hutter, arXiv:1711.05101 Algorithm 2 for AdamW and
+# Pagliardini et al., arXiv:2409.03137 for AdEMAMix; torch.optim.AdamW does the same.
+str2optimizers_weight_decay = {
+    "adamw": (torch.optim.AdamW, bnb.optim.AdamW),
+    "ademamix": (bnb.optim.ademamix._ReferenceAdEMAMix, bnb.optim.AdEMAMix),
+}
+
+str2optimizers_weight_decay_8bit = {
+    "adamw8bit_blockwise": bnb.optim.AdamW8bit,
+    "ademamix8bit_blockwise": bnb.optim.AdEMAMix8bit,
+}
+
+
+@pytest.mark.parametrize("optim_name", list(str2optimizers_weight_decay), ids=id_formatter("opt"))
+@pytest.mark.parametrize("dim1", [1024], ids=id_formatter("dim1"))
+@pytest.mark.parametrize("dim2", [32, 1024], ids=id_formatter("dim2"))
+@pytest.mark.parametrize("device", get_available_devices(), ids=id_formatter("device"))
+def test_optimizer32bit_weight_decay(dim1, dim2, optim_name, device):
+    """AdamW/AdEMAMix must apply decoupled weight decay to the previous parameter, not to
+    the parameter after the update has been added.
+
+    The two orderings differ by lr*wd*|update| per step, so the separation grows with
+    lr*lr*wd while the kernel's own arithmetic error only grows with lr. test_optimizer32bit
+    runs these optimizers at the default weight_decay of 0, and at the lr=1e-3, wd=0.01 an
+    Adam user would typically pick the orderings stay 1.7e-7 apart, inside its 1e-6
+    tolerance. At lr=0.1, wd=0.1 they are ~1e-3 apart while agreement with the reference
+    stays at 3.9e-5 on CUDA, which is the gap this tolerance sits in.
+
+    fp32 only: the ordering is a property of the float math inside the kernel and does not
+    depend on the parameter storage dtype, and the 16-bit variants of test_optimizer32bit
+    resynchronise the parameters after every step, so at most one step of divergence is
+    ever visible and it stays inside the looser 16-bit tolerances.
+    """
+    lr, weight_decay = 0.1, 0.1
+
+    p1 = torch.randn(dim1, dim2, device=device) * 0.1
+    p2 = p1.clone()
+
+    ref_cls, bnb_cls = str2optimizers_weight_decay[optim_name]
+    torch_optimizer = ref_cls([p1], lr=lr, weight_decay=weight_decay)
+    bnb_optimizer = bnb_cls([p2], lr=lr, weight_decay=weight_decay)
+
+    for _ in range(k):
+        g = torch.randn(dim1, dim2, device=device) * 0.01
+        p1.grad = g.clone()
+        p2.grad = g.clone()
+
+        bnb_optimizer.step()
+        torch_optimizer.step()
+
+        assert_most_approx_close(p1, p2, atol=1e-4, rtol=1e-3, max_error_count=0)
+
+
+@pytest.mark.parametrize("optim_name", list(str2optimizers_weight_decay_8bit), ids=id_formatter("opt"))
+@pytest.mark.parametrize("dim1", [1024], ids=id_formatter("dim1"))
+@pytest.mark.parametrize("dim2", [32, 1024], ids=id_formatter("dim2"))
+@pytest.mark.parametrize("device", get_available_devices(), ids=id_formatter("device"))
+def test_optimizer8bit_weight_decay(dim1, dim2, optim_name, device):
+    """Same decoupled weight decay requirement for the 8-bit blockwise kernels.
+
+    Comparing a full run against a 32-bit reference cannot see this: the state
+    quantization error is ~6.6e-4 per step while the two decay orderings differ by
+    ~1.6e-6. The first step is exempt, because the optimizer state is still zero and
+    therefore quantizes exactly, so one step from a fresh optimizer has a closed form:
+
+        m = (1-b1)g, v = (1-b2)g^2  =>  update = -lr*g/(|g| + eps)
+
+    and AdEMAMix also mixes in alpha*(1-b3)*g. Decoupled decay then gives
+    p1 = p0*(1 - lr*wd) + update, while applying decay afterwards scales the update
+    term by an extra (1 - lr*wd), which at these hyperparameters is 1.0e-3 away.
+
+    The tolerance is set above the 3.0e-6 the CUDA kernels leave against the closed form,
+    which comes from their fast intrinsics (__powf, __fdividef) rather than from the decay.
+    """
+    if device == "mps":
+        pytest.skip("8-bit optimizers are not implemented for MPS")
+
+    lr, weight_decay, eps = 0.1, 0.1, 1e-8
+
+    p0 = torch.randn(dim1, dim2, device=device) * 0.1
+    p = p0.clone()
+    g = torch.randn(dim1, dim2, device=device) * 0.01
+
+    bnb_optimizer = str2optimizers_weight_decay_8bit[optim_name]([p], lr=lr, weight_decay=weight_decay, eps=eps)
+    p.grad = g.clone()
+    bnb_optimizer.step()
+
+    update = -lr * g / (g.abs() + eps)
+    if optim_name.startswith("ademamix"):
+        group = bnb_optimizer.param_groups[0]
+        alpha = group["alpha"]
+        beta3 = group["betas"][2]
+        update = update * (1.0 + alpha * (1.0 - beta3))
+
+    expected = p0 * (1.0 - lr * weight_decay) + update
+
+    torch.testing.assert_close(p, expected, atol=1e-5, rtol=1e-4)
+
+
 @pytest.mark.parametrize("dim1", [1024], ids=id_formatter("dim1"))
 @pytest.mark.parametrize("dim2", [32, 1024, 4097], ids=id_formatter("dim2"))
 @pytest.mark.parametrize("gtype", [torch.float32, torch.float16], ids=describe_dtype)


### PR DESCRIPTION
Closes #2010.

The CUDA 2-state optimizer kernels apply weight decay after adding the update:

```
p = (p + step_size*update) * (1 - lr*wd)
```

which expands to `p*(1 - lr*wd) + step_size*update*(1 - lr*wd)`. The extra factor on the update term is not in AdamW Algorithm 2 (Loshchilov and Hutter, arXiv:1711.05101) or in the AdEMAMix update rule (Pagliardini et al., arXiv:2409.03137). Both take the decay and the gradient-based update from the same previous parameter, which rearranges to `p*(1 - lr*wd) + step_size*update`. `torch.optim.AdamW` does the same, and so do the cpu, default and triton backends here.

Three sites in `csrc/kernels.cu`: the `ADAM` and `ADEMAMIX` branches of `kOptimizer32bit2State`, and the 2-state branch of `kOptimizerStatic8bit2StateBlockwise`. The change is a reorder, 9 insertions and 8 deletions. The 1-state kernels already use coupled L2 for momentum/rmsprop/adagrad and decoupled decay for Lion, matching the Python backends, so they are untouched.

@ErenAta16 reported this and worked out in the thread that CUDA is the side that diverges. @egeozkoc confirmed it against the paper, pointed out that the 8-bit blockwise kernel is affected too, and offered to write the expanded weight-decay tests. I went ahead because the issue had been sitting for about a month. Happy to close this if either of you would rather carry it.

## This changes results for existing users

CUDA runs using Adam, AdamW, LAMB or AdEMAMix with `weight_decay > 0` will follow different training trajectories after this. The per-step difference is `lr*wd*|update|`. Runs with `weight_decay = 0` are unaffected, as are the cpu, default, triton and XPU backends, which already used this ordering.

## Why the current tests do not catch it

They run these optimizers at the default `weight_decay` of 0, where the two orderings coincide. At the lr=1e-3, wd=0.01 an Adam user would typically pick, 20 steps leave the orderings 1.7e-7 apart, inside the 1e-6 tolerance. The entire existing `test_optim.py` passes on the unfixed kernel:

```
$ BNB_TEST_DEVICE=cuda pytest tests/test_optim.py -q -k "not weight_decay"   # unfixed kernel
213 passed, 12 skipped, 35 deselected, 194 warnings in 61.97s
```

The two orderings separate as `lr*lr*wd`, while the kernels' own arithmetic error grows only as `lr`. So `test_optimizer32bit_weight_decay` runs at lr=0.1, wd=0.1, where the orderings are 1.0e-3 apart and agreement with the reference is 3.9e-5.

`test_optimizer8bit_weight_decay` cannot use a full run at all: the state quantization error is 6.6e-4 per step while the orderings differ by 1.6e-6, so the signal is buried. It instead takes one step from a fresh optimizer, where the state is still zero and therefore quantizes exactly, and the update reduces to `-lr*g/(|g| + eps)` (AdEMAMix also mixes in `alpha*(1-b3)*g`). At those hyperparameters the orderings are 1.0e-3 apart, and the fixed kernels sit 3.0e-6 from the closed form, which is `__powf` and `__fdividef` rather than the decay. Both tests are fp32; the 16-bit paths in `test_optimizer32bit` resynchronise the parameters every step, so at most one step of divergence is visible there and it stays inside the looser 16-bit tolerances.

## Verification

RTX 3090, sm_86, CUDA 12.4, torch 2.5.1+cu124, built from source with `-DCOMPUTE_CAPABILITY=86`. Only `csrc/kernels.cu` was reverted between the two runs; the tests were identical.

```
$ BNB_TEST_DEVICE=cuda pytest tests/test_optim.py -q -k weight_decay     # kernels.cu reverted
E  Greatest absolute difference: 0.0010029971599578857 at index (7, 2) (up to 0.0001 allowed)
E  Greatest absolute difference: 0.0010035037994384766 at index (329, 20) (up to 1e-05 allowed)
8 failed, 252 deselected in 16.44s

$ BNB_TEST_DEVICE=cuda pytest tests/test_optim.py -q -k weight_decay     # fix applied
8 passed, 252 deselected in 18.81s

$ BNB_TEST_DEVICE=cuda pytest tests/test_optim.py -q                     # fix applied, full module
221 passed, 12 skipped, 27 deselected, 194 warnings in 83.19s
```

Isolating the ordering on one step, same hardware, with the fix applied:

```
AdamW-32bit: |p-decay_first|=3.040e-06   |p-decay_after|=9.971e-04
AdamW-8bit:  |p-decay_first|=3.040e-06   |p-decay_after|=9.971e-04
```

On cpu and mps, which already had the correct ordering, the new tests pass unchanged (`8 passed` on cpu, `4 passed, 4 skipped` on mps; the 8-bit ones skip because `optimizer_update_8bit_blockwise` has no MPS kernel). To check they are not vacuous without a GPU, I also re-registered the cpu kernels with the CUDA ordering and confirmed all 8 fail.

`pre-commit run --all-files` passes.

## Not covered

`bnb.optim.Adam` applies decoupled decay in every backend, so with `weight_decay > 0` it matches `torch.optim.AdamW` rather than `torch.optim.Adam` (on cpu, 60 steps at lr=1e-2, wd=0.1: max 5.3e-1 from `torch.optim.Adam`, 1.5e-7 from `torch.optim.AdamW`). That is the separate point you raised in the issue and it is not touched here. The `skip_zeros` path still skips the decay along with the update when a gradient is exactly zero, which is existing behaviour I left alone. I verified on sm_86 only.
