### PR TITLE
ci: expand ROCm architecture coverage

### DIFF
--- a/.github/scripts/build-rocm.sh
+++ b/.github/scripts/build-rocm.sh
@@ -35,9 +35,9 @@ if rocm_version_at_least "7.0"; then
     bnb_rocm_arch="${bnb_rocm_arch};gfx950"
 fi
 
-# ROCm 7.14+ - Add CDNA1 and RDNA2 targets.
+# ROCm 7.14+ - Add CDNA1, RDNA1, and RDNA2 targets.
 if rocm_version_at_least "7.14"; then
-    bnb_rocm_arch="${bnb_rocm_arch};gfx908;gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036"
+    bnb_rocm_arch="${bnb_rocm_arch};gfx908;gfx1010;gfx1011;gfx1012;gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036"
 fi
 
 # ROCm 7.14+ - Add CDNA5 (gfx1250).
@@ -61,8 +61,8 @@ else
     bnb_rocm_arch="gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201"
 
     if rocm_version_at_least "7.14"; then
-        # Add RDNA2 and additional RDNA3.5 targets.
-        bnb_rocm_arch="${bnb_rocm_arch};gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036;gfx1152;gfx1153"
+        # Add RDNA1, RDNA2, and additional RDNA3.5 targets.
+        bnb_rocm_arch="${bnb_rocm_arch};gfx1010;gfx1011;gfx1012;gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036;gfx1152;gfx1153"
 
         pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "rocm[libraries,devel]==${ROCM_VERSION}"
     else

--- a/.github/scripts/build-rocm.sh
+++ b/.github/scripts/build-rocm.sh
@@ -23,7 +23,7 @@ rocm_version_at_least() {
     return 1
 }
 
-bnb_rocm_arch="gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1103"
+bnb_rocm_arch="gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103"
 
 # ROCm 6.4+ - Add RDNA4 and RDNA3.5 targets. Note we assume >=6.4.4.
 if rocm_version_at_least "6.4"; then
@@ -35,9 +35,9 @@ if rocm_version_at_least "7.0"; then
     bnb_rocm_arch="${bnb_rocm_arch};gfx950"
 fi
 
-# ROCm 7.14+ - Add CDNA1, RDNA1, and RDNA2 targets.
+# ROCm 7.14+ - Add RDNA1 and additional RDNA2 targets.
 if rocm_version_at_least "7.14"; then
-    bnb_rocm_arch="${bnb_rocm_arch};gfx908;gfx1010;gfx1011;gfx1012;gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036"
+    bnb_rocm_arch="${bnb_rocm_arch};gfx1010;gfx1011;gfx1012;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036"
 fi
 
 # ROCm 7.14+ - Add CDNA5 (gfx1250).
@@ -61,8 +61,8 @@ else
     bnb_rocm_arch="gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201"
 
     if rocm_version_at_least "7.14"; then
-        # Add RDNA1, RDNA2, and additional RDNA3.5 targets.
-        bnb_rocm_arch="${bnb_rocm_arch};gfx1010;gfx1011;gfx1012;gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036;gfx1152;gfx1153"
+        # Add the remaining targets available from the Windows multi-architecture index.
+        bnb_rocm_arch="${bnb_rocm_arch};gfx908;gfx90a;gfx1010;gfx1011;gfx1012;gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036;gfx1103;gfx1152;gfx1153"
 
         pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "rocm[libraries,devel]==${ROCM_VERSION}"
     else

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,7 @@ elseif(BUILD_HIP)
     elseif(AMDGPU_TARGETS AND NOT CMAKE_HIP_ARCHITECTURES)
       set(CMAKE_HIP_ARCHITECTURES ${AMDGPU_TARGETS})
     elseif(NOT CMAKE_HIP_ARCHITECTURES)
-      set(CMAKE_HIP_ARCHITECTURES "gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201")
+      set(CMAKE_HIP_ARCHITECTURES "gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201")
     endif()
 
     enable_language(HIP)

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ bitsandbytes has the following minimum requirements for all platforms:
       <td></td>
       <td>🟥 AMD GPU <br><code>cuda</code></td>
       <td>
+        CDNA: gfx908, gfx90a<br>
         RDNA: gfx101X, gfx103X, gfx110X, gfx115X, gfx120X
       </td>
       <td>✅</td>

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ bitsandbytes has the following minimum requirements for all platforms:
       <td>🟥 AMD GPU <br><code>cuda</code></td>
       <td>
         CDNA: gfx908, gfx90a, gfx942, gfx950, gfx1250<br>
-        RDNA: gfx103X, gfx110X, gfx115X, gfx120X
+        RDNA: gfx101X, gfx103X, gfx110X, gfx115X, gfx120X
       </td>
       <td>✅</td>
       <td>✅</td>
@@ -136,7 +136,7 @@ bitsandbytes has the following minimum requirements for all platforms:
       <td></td>
       <td>🟥 AMD GPU <br><code>cuda</code></td>
       <td>
-        RDNA: gfx103X, gfx110X, gfx115X, gfx120X
+        RDNA: gfx101X, gfx103X, gfx110X, gfx115X, gfx120X
       </td>
       <td>✅</td>
       <td>✅</td>

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -166,9 +166,9 @@ The currently distributed `bitsandbytes` are built with the following configurat
 | **Linux x86-64**   | 7.0.2    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 | **Linux x86-64**   | 7.1.1    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 | **Linux x86-64**   | 7.2.4    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
-| **Linux x86-64**   | 7.14.0   | CDNA: gfx908, gfx90a, gfx942, gfx950, gfx1250 / RDNA: gfx1030, gfx1031, gfx1032, gfx1033, gfx1034, gfx1035, gfx1036, gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
+| **Linux x86-64**   | 7.14.0   | CDNA: gfx908, gfx90a, gfx942, gfx950, gfx1250 / RDNA: gfx1010, gfx1011, gfx1012, gfx1030, gfx1031, gfx1032, gfx1033, gfx1034, gfx1035, gfx1036, gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 | **Windows x86-64** | 7.2.1    | RDNA: gfx1100, gfx1101, gfx1102, gfx1150, gfx1151, gfx1200, gfx1201
-| **Windows x86-64** | 7.14.0   | RDNA: gfx1030, gfx1031, gfx1032, gfx1033, gfx1034, gfx1035, gfx1036, gfx1100, gfx1101, gfx1102, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
+| **Windows x86-64** | 7.14.0   | RDNA: gfx1010, gfx1011, gfx1012, gfx1030, gfx1031, gfx1032, gfx1033, gfx1034, gfx1035, gfx1036, gfx1100, gfx1101, gfx1102, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 
 Use `pip` or `uv` to install the latest release:
 

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -162,13 +162,13 @@ The currently distributed `bitsandbytes` are built with the following configurat
 
 | **OS**             | **ROCm** | **Targets**
 |--------------------|----------|---------------------------------------------------------------------|
-| **Linux x86-64**   | 6.4.4    | CDNA: gfx90a, gfx942 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
-| **Linux x86-64**   | 7.0.2    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
-| **Linux x86-64**   | 7.1.1    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
-| **Linux x86-64**   | 7.2.4    | CDNA: gfx90a, gfx942, gfx950 / RDNA: gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
+| **Linux x86-64**   | 6.4.4    | CDNA: gfx908, gfx90a, gfx942 / RDNA: gfx1030, gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
+| **Linux x86-64**   | 7.0.2    | CDNA: gfx908, gfx90a, gfx942, gfx950 / RDNA: gfx1030, gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
+| **Linux x86-64**   | 7.1.1    | CDNA: gfx908, gfx90a, gfx942, gfx950 / RDNA: gfx1030, gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
+| **Linux x86-64**   | 7.2.4    | CDNA: gfx908, gfx90a, gfx942, gfx950 / RDNA: gfx1030, gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 | **Linux x86-64**   | 7.14.0   | CDNA: gfx908, gfx90a, gfx942, gfx950, gfx1250 / RDNA: gfx1010, gfx1011, gfx1012, gfx1030, gfx1031, gfx1032, gfx1033, gfx1034, gfx1035, gfx1036, gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 | **Windows x86-64** | 7.2.1    | RDNA: gfx1100, gfx1101, gfx1102, gfx1150, gfx1151, gfx1200, gfx1201
-| **Windows x86-64** | 7.14.0   | RDNA: gfx1010, gfx1011, gfx1012, gfx1030, gfx1031, gfx1032, gfx1033, gfx1034, gfx1035, gfx1036, gfx1100, gfx1101, gfx1102, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
+| **Windows x86-64** | 7.14.0   | CDNA: gfx908, gfx90a / RDNA: gfx1010, gfx1011, gfx1012, gfx1030, gfx1031, gfx1032, gfx1033, gfx1034, gfx1035, gfx1036, gfx1100, gfx1101, gfx1102, gfx1103, gfx1150, gfx1151, gfx1152, gfx1153, gfx1200, gfx1201
 
 Use `pip` or `uv` to install the latest release:
 


### PR DESCRIPTION
## Summary

- add RDNA1 targets `gfx1010`, `gfx1011`, and `gfx1012` to the ROCm 7.14 Linux and Windows artifacts
- add `gfx908` and `gfx1030` to every supported Linux ROCm build
- align the Windows ROCm 7.14 artifact with AMD's multi-architecture index by adding `gfx908`, `gfx90a`, and `gfx1103`
- update the README platform summary and installation target matrix to document the expanded coverage

## Architecture additions

| ROCm | Linux additions | Windows additions |
|---|---|---|
| 6.4.4 | `gfx908`, `gfx1030` | Not built |
| 7.0.2 | `gfx908`, `gfx1030` | Not built |
| 7.1.1 | `gfx908`, `gfx1030` | Not built |
| 7.2.1 | Not built | No change; existing targets match the PyTorch wheel |
| 7.2.4 | `gfx908`, `gfx1030` | Not built |
| 7.14.0 | `gfx1010`, `gfx1011`, `gfx1012` | `gfx908`, `gfx90a`, `gfx1010`, `gfx1011`, `gfx1012`, `gfx1103` |

## Validation

- `pre-commit run --all-files`
- `bash -n .github/scripts/build-rocm.sh`
- compared ROCm 7.14 targets with the platform-specific device wheels in https://repo.amd.com/rocm/whl-multi-arch/
- downloaded and inspected all 207 HIP fat-binary bundles in the Windows ROCm 7.2.1 PyTorch wheel; confirmed its existing bitsandbytes target list already exactly matches `gfx1100`, `gfx1101`, `gfx1102`, `gfx1150`, `gfx1151`, `gfx1200`, and `gfx1201`