### PR TITLE
Chunk 4-bit quant/dequant when numel exceeds int32

### DIFF
--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 import ctypes as ct
 import itertools
 from math import prod
@@ -859,6 +859,102 @@ def get_4bit_type(typename, device=None, blocksize=64):
     return data
 
 
+# CUDA/C++ 4-bit kernels take `const int n` (int32). numel() == 2**31
+# (e.g. fused MoE expert weights [128, 4096, 4096]) overflows and fails
+# with cudaErrorInvalidArgument. Chunk on a blocksize-aligned split.
+# Kernel-level int64 indexing is tracked in #1785.
+_INT32_MAX = 2**31 - 1
+
+
+def _max_int32_chunk_numel(blocksize: int) -> int:
+    n = (_INT32_MAX // blocksize) * blocksize
+    return n if n > 0 else blocksize
+
+
+def _quantize_4bit_op(
+    A: torch.Tensor, blocksize: int, quant_type: str, quant_storage: torch.dtype
+) -> tuple[torch.Tensor, torch.Tensor]:
+    n = A.numel()
+    if n <= _INT32_MAX:
+        return torch.ops.bitsandbytes.quantize_4bit.default(A, blocksize, quant_type, quant_storage)
+
+    max_chunk = _max_int32_chunk_numel(blocksize)
+    n_blocks = (n + blocksize - 1) // blocksize
+    n_packed = (n + 1) // (quant_storage.itemsize * 2)
+    out = torch.empty((n_packed, 1), device=A.device, dtype=quant_storage)
+    absmax = torch.empty((n_blocks,), device=A.device, dtype=torch.float32)
+
+    flat = A.reshape(-1)
+    elem_off = 0
+    pack_off = 0
+    abs_off = 0
+    while elem_off < n:
+        n_chunk = min(max_chunk, n - elem_off)
+        q_chunk, am_chunk = torch.ops.bitsandbytes.quantize_4bit.default(
+            flat[elem_off : elem_off + n_chunk],
+            blocksize,
+            quant_type,
+            quant_storage,
+        )
+        n_pack = q_chunk.numel()
+        n_am = am_chunk.numel()
+        out.view(-1)[pack_off : pack_off + n_pack].copy_(q_chunk.reshape(-1))
+        absmax[abs_off : abs_off + n_am].copy_(am_chunk.reshape(-1))
+        elem_off += n_chunk
+        pack_off += n_pack
+        abs_off += n_am
+
+    return out, absmax
+
+
+def _dequantize_4bit_op(
+    A: torch.Tensor,
+    absmax: torch.Tensor,
+    blocksize: int,
+    quant_type: str,
+    shape: Sequence[int],
+    dtype: torch.dtype,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    n = int(prod(shape))
+    if n <= _INT32_MAX:
+        if out is not None:
+            torch.ops.bitsandbytes.dequantize_4bit.out(A, absmax, blocksize, quant_type, shape, dtype, out=out)
+            return out
+        return torch.ops.bitsandbytes.dequantize_4bit.default(A, absmax, blocksize, quant_type, shape, dtype)
+
+    max_chunk = _max_int32_chunk_numel(blocksize)
+    result = out if out is not None else torch.empty(shape, dtype=dtype, device=A.device)
+    flat_out = result.reshape(-1)
+    packed = A.reshape(-1)
+    packed_itemsize = A.element_size()
+
+    elem_off = 0
+    pack_off = 0
+    abs_off = 0
+    while elem_off < n:
+        n_chunk = min(max_chunk, n - elem_off)
+        n_blocks = (n_chunk + blocksize - 1) // blocksize
+        n_packed = (n_chunk + 1) // (packed_itemsize * 2)
+        # Column vector so dequantize_4bit's A.shape[0] == 1 transpose shim cannot fire
+        # if a future caller routes chunks through the Python wrapper.
+        chunk_A = packed[pack_off : pack_off + n_packed].reshape(-1, 1)
+        chunk_dq = torch.ops.bitsandbytes.dequantize_4bit.default(
+            chunk_A,
+            absmax[abs_off : abs_off + n_blocks],
+            blocksize,
+            quant_type,
+            (n_chunk,),
+            dtype,
+        )
+        flat_out[elem_off : elem_off + n_chunk].copy_(chunk_dq.reshape(-1))
+        elem_off += n_chunk
+        pack_off += n_packed
+        abs_off += n_blocks
+
+    return result
+
+
 def quantize_fp4(
     A: torch.Tensor,
     absmax: Optional[torch.Tensor] = None,
@@ -926,12 +1022,7 @@ def quantize_4bit(
 
     input_shape = A.shape
 
-    _out, _absmax = torch.ops.bitsandbytes.quantize_4bit.default(
-        A,
-        blocksize,
-        quant_type,
-        quant_storage,
-    )
+    _out, _absmax = _quantize_4bit_op(A, blocksize, quant_type, quant_storage)
 
     code = get_4bit_type(quant_type, device=A.device)
 
@@ -1055,19 +1146,15 @@ def dequantize_4bit(
         if absmax.dtype != torch.float32:
             absmax = absmax.float()
 
-    if out is not None:
-        torch.ops.bitsandbytes.dequantize_4bit.out(
-            A, absmax, quant_state.blocksize, quant_state.quant_type, quant_state.shape, quant_state.dtype, out=out
-        )
-    else:
-        out = torch.ops.bitsandbytes.dequantize_4bit.default(
-            A,
-            absmax,
-            quant_state.blocksize,
-            quant_state.quant_type,
-            quant_state.shape,
-            quant_state.dtype,
-        )
+    out = _dequantize_4bit_op(
+        A,
+        absmax,
+        quant_state.blocksize,
+        quant_state.quant_type,
+        quant_state.shape,
+        quant_state.dtype,
+        out=out,
+    )
 
     # BC shim: callers that pass the packed weight in transposed [1, (N*K+1)//2] form
     # receive the output transposed back to [K, N]. bnb's own paths no longer trigger

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -702,7 +702,8 @@ class TestQuantize4BitFunctional:
     def test_4bit_quant_large(self, device, dtype, quant_type, blocksize):
         """
         Test that we can successfully quantize a large tensor. Note that the following limitations apply:
-        - On CUDA/XPU/ROCm, the maximum number of elements is limited to 2**31 - 1 due to int32 indexing in C++ kernels.
+        - CUDA/C++ 4-bit kernels take int32 `n`; tensors with numel() > 2**31 - 1 are
+          chunked in `quantize_4bit` / `dequantize_4bit` (see #1785).
         - On CUDA, this test requires ~10GiB of memory for fp32
         - On CPU, there is a significantly higher memory overhead for the quantization, so we skip this test.
         - Verification of the accuracy for dequantization has too high memory overhead for this test.
@@ -724,6 +725,69 @@ class TestQuantize4BitFunctional:
 
         assert dq.dtype == dtype
         assert dq.numel() == 2**31 - 1
+
+    @pytest.mark.parametrize("device", get_available_devices())
+    @pytest.mark.parametrize("quant_type", ["fp4", "nf4"])
+    @pytest.mark.parametrize("blocksize", [64, 128], ids=id_formatter("blocksize"))
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=describe_dtype)
+    @pytest.mark.parametrize("compress_statistics", [False, True])
+    def test_4bit_quant_chunks_above_int32_limit(
+        self, monkeypatch, device, quant_type, blocksize, dtype, compress_statistics
+    ):
+        """Chunked 4-bit path must match a single kernel launch.
+
+        Kernels cannot take numel() > int32. Lower the threshold so the
+        chunked path runs on small tensors instead of allocating 2**31 elements.
+        """
+        if device == "hpu" and not is_supported_on_hpu(quant_type, dtype):
+            pytest.skip("This configuration is not supported on HPU.")
+
+        # Two full chunks plus a short remainder, including a 3-D MoE-style layout.
+        monkeypatch.setattr(F, "_INT32_MAX", 4 * blocksize)
+        A = torch.randn(3, 5, 7 * blocksize + 13, device=device, dtype=dtype)
+
+        q_chunked, state_chunked = F.quantize_4bit(
+            A, blocksize=blocksize, quant_type=quant_type, compress_statistics=compress_statistics
+        )
+
+        monkeypatch.setattr(F, "_INT32_MAX", 2**31 - 1)
+        q_ref, state_ref = F.quantize_4bit(
+            A, blocksize=blocksize, quant_type=quant_type, compress_statistics=compress_statistics
+        )
+
+        torch.testing.assert_close(q_chunked, q_ref, rtol=0, atol=0)
+        assert state_chunked.shape == A.shape
+        assert tuple(state_chunked.shape) == tuple(state_ref.shape)
+        assert state_chunked.blocksize == blocksize
+        assert state_chunked.quant_type == quant_type
+        assert state_chunked.dtype == dtype
+        assert state_chunked.nested is compress_statistics
+
+        dq_chunked = F.dequantize_4bit(q_chunked, state_chunked)
+        dq_ref = F.dequantize_4bit(q_ref, state_ref)
+        torch.testing.assert_close(dq_chunked, dq_ref, rtol=0, atol=0)
+        assert dq_chunked.shape == A.shape
+        assert dq_chunked.dtype == dtype
+
+        monkeypatch.setattr(F, "_INT32_MAX", 4 * blocksize)
+        dq_chunked_limit = F.dequantize_4bit(q_ref, state_ref)
+        torch.testing.assert_close(dq_chunked_limit, dq_ref, rtol=0, atol=0)
+
+    @pytest.mark.parametrize("device", get_available_devices())
+    def test_4bit_quant_chunks_respects_out_and_quant_storage(self, monkeypatch, device):
+        monkeypatch.setattr(F, "_INT32_MAX", 256)
+        A = torch.randn(400, device=device, dtype=torch.float16)
+        storage = torch.uint8
+        n_packed = (A.numel() + 1) // (storage.itemsize * 2)
+        out = torch.empty((n_packed, 1), device=device, dtype=storage)
+
+        q, state = F.quantize_4bit(A, blocksize=64, quant_type="nf4", out=out, quant_storage=storage)
+        assert q.data_ptr() == out.data_ptr()
+
+        dq_out = torch.empty_like(A)
+        dq = F.dequantize_4bit(q, state, out=dq_out)
+        assert dq.data_ptr() == dq_out.data_ptr()
+        torch.testing.assert_close(dq, F.dequantize_4bit(q, state))
 
     # @pytest.mark.parametrize("quant_type", ['fp4', 'nf4'])
     @pytest.mark.parametrize("quant_type", ["nf4"])


### PR DESCRIPTION
### Problem

CUDA/C++ 4-bit kernels take `const int n`. Tensors with `numel() == 2**31` overflow that argument and die with `cudaErrorInvalidArgument` at `ops.cu` (kernel launch).

This shows up when loading fused MoE expert weights as a single 3-D parameter, e.g. Mistral 4 `mlp.experts.gate_up_proj` of shape `[128, 4096, 4096] = 2**31`. Dropping 4-bit quantization of those experts is not a real fix: 36 layers of bf16 `gate_up_proj` is on the order of 144 GiB.

Related: #1785 (high-priority 4-bit blockwise quant/dequant). Kernel-level int64 indexing is still the longer-term path; this PR unblocks the public Python API without a C ABI change (Unsloth and other ctypes callers are unaffected).

### What this adds

`quantize_4bit` / `dequantize_4bit` split work into blocksize-aligned chunks of at most `2**31 - 1` elements, write into a single packed tensor / `QuantState`, then (if requested) run nested `compress_statistics` on the concatenated absmax.

- Common-case tensors with `numel() <= INT_MAX` still take the existing single-launch path.
- Chunk absmax is concatenated first, then double-quantized, so nested state matches a single launch.
- Packed layout stays `(n_packed, 1)` so the `A.shape[0] == 1` dequant transpose shim does not fire on chunks.

### Tests

- Existing `test_4bit_quant` (all blocksizes / dtypes / fp4+nf4 on CPU): pass.
- New `test_4bit_quant_chunks_above_int32_limit`: lowers `_INT32_MAX` so the chunked path runs on small 3-D tensors and asserts **bit-exact** packed weights and dequant vs a single launch (fp4/nf4, with and without `compress_statistics`).
- New `test_4bit_quant_chunks_respects_out_and_quant_storage`: `out=` still aliases the provided tensor.

This machine has no GPU, so CUDA was not exercised locally. The chunking is in `functional.py` and is backend-agnostic.

Does **not** close #1785: 4-bit GEMV, LLM.int8(), and 8-bit optimizers still use int32 `n`.

cc @matthewdouglas