### PR TITLE
Respect the current CUDA stream in blockwise quantization

### DIFF
--- a/benchmarking/quantize_blockwise_stream.py
+++ b/benchmarking/quantize_blockwise_stream.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Benchmark legacy stream-0 and current-stream blockwise quantization."""
+
+import argparse
+from contextlib import contextmanager
+import ctypes as ct
+import json
+import os
+from pathlib import Path
+import random
+import statistics
+import time
+
+import torch
+
+import bitsandbytes as bnb
+from bitsandbytes.backends.cuda import ops as cuda_ops
+import bitsandbytes.functional as F
+
+DTYPES = {
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+    "fp32": torch.float32,
+}
+QUANT_TYPES = ("general8", "fp4", "nf4")
+
+
+def percentile(values: list[float], q: float) -> float:
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * q
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def bootstrap_ratio_ci(baseline: list[float], candidate: list[float], iterations: int = 2000) -> tuple[float, float]:
+    rng = random.Random(0)
+    ratios = []
+    for _ in range(iterations):
+        indices = [rng.randrange(len(baseline)) for _ in baseline]
+        baseline_median = statistics.median(baseline[index] for index in indices)
+        candidate_median = statistics.median(candidate[index] for index in indices)
+        ratios.append(baseline_median / candidate_median)
+    return percentile(ratios, 0.025), percentile(ratios, 0.975)
+
+
+def summarize(baseline: list[float], candidate: list[float], round_size: int) -> dict:
+    baseline_median = statistics.median(baseline)
+    candidate_median = statistics.median(candidate)
+    ci_low, ci_high = bootstrap_ratio_ci(baseline, candidate)
+    return {
+        "baseline_samples": baseline,
+        "candidate_samples": candidate,
+        "baseline_median": baseline_median,
+        "baseline_p10": percentile(baseline, 0.1),
+        "baseline_p90": percentile(baseline, 0.9),
+        "candidate_median": candidate_median,
+        "candidate_p10": percentile(candidate, 0.1),
+        "candidate_p90": percentile(candidate, 0.9),
+        "baseline_round_medians": [
+            statistics.median(baseline[start : start + round_size]) for start in range(0, len(baseline), round_size)
+        ],
+        "candidate_round_medians": [
+            statistics.median(candidate[start : start + round_size]) for start in range(0, len(candidate), round_size)
+        ],
+        "ratio": baseline_median / candidate_median,
+        "ratio_ci95_low": ci_low,
+        "ratio_ci95_high": ci_high,
+    }
+
+
+def configure_legacy_library(path: Path):
+    library = ct.CDLL(str(path))
+    argtypes = [ct.c_void_p] * 4 + [ct.c_int32, ct.c_int32]
+    for dtype_name in DTYPES:
+        for suffix in ("", "_fp4", "_nf4"):
+            function = getattr(library, f"cquantize_blockwise_{dtype_name}{suffix}")
+            function.argtypes = argtypes
+            function.restype = None
+    return library
+
+
+def native_function(library, dtype_name: str, quant_type: str, with_stream: bool):
+    suffix = "" if quant_type == "general8" else f"_{quant_type}"
+    stream_suffix = "_with_stream" if with_stream else ""
+    return getattr(library, f"cquantize_blockwise_{dtype_name}{suffix}{stream_suffix}")
+
+
+def allocate_direct(n: int, dtype_name: str, quant_type: str, blocksize: int):
+    dtype = DTYPES[dtype_name]
+    tensor = torch.linspace(-4.0, 4.0, n, dtype=torch.float32, device="cuda").to(dtype)
+    blocks = -(n // -blocksize)
+    output_size = n if quant_type == "general8" else (n + 1) // 2
+    output = torch.empty(output_size, dtype=torch.uint8, device="cuda")
+    absmax = torch.empty(blocks, dtype=torch.float32, device="cuda")
+    code = F.create_dynamic_map().to("cuda") if quant_type == "general8" else None
+    return tensor, output, absmax, code
+
+
+def invoke_direct(function, tensors, blocksize: int, with_stream: bool) -> None:
+    tensor, output, absmax, code = tensors
+    arguments = [
+        code.data_ptr() if code is not None else None,
+        tensor.data_ptr(),
+        absmax.data_ptr(),
+        output.data_ptr(),
+        blocksize,
+        tensor.numel(),
+    ]
+    if with_stream:
+        arguments.append(cuda_ops._get_raw_stream(tensor.device.index))
+    function(*arguments)
+
+
+def event_us(function, tensors, blocksize: int, with_stream: bool) -> float:
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    invoke_direct(function, tensors, blocksize, with_stream)
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) * 1000.0
+
+
+def direct_repetitions(n: int, requested: int) -> int:
+    if n <= 1 << 20:
+        return requested
+    if n <= 1 << 24:
+        return min(requested, 50)
+    if n <= 1 << 27:
+        return min(requested, 20)
+    return min(requested, 8)
+
+
+def benchmark_direct_case(
+    baseline_library,
+    candidate_library,
+    dtype_name: str,
+    quant_type: str,
+    n: int,
+    blocksize: int,
+    warmup: int,
+    rounds: int,
+    repetitions: int,
+) -> dict:
+    baseline_tensors = allocate_direct(n, dtype_name, quant_type, blocksize)
+    candidate_tensors = allocate_direct(n, dtype_name, quant_type, blocksize)
+    candidate_tensors[0].copy_(baseline_tensors[0])
+    baseline_function = native_function(baseline_library, dtype_name, quant_type, False)
+    candidate_function = native_function(candidate_library, dtype_name, quant_type, True)
+
+    for index in range(warmup):
+        if index % 2:
+            invoke_direct(candidate_function, candidate_tensors, blocksize, True)
+            invoke_direct(baseline_function, baseline_tensors, blocksize, False)
+        else:
+            invoke_direct(baseline_function, baseline_tensors, blocksize, False)
+            invoke_direct(candidate_function, candidate_tensors, blocksize, True)
+    torch.cuda.synchronize()
+
+    baseline_samples = []
+    candidate_samples = []
+    for round_index in range(rounds):
+        for sample_index in range(repetitions):
+            if (round_index + sample_index) % 2:
+                candidate_samples.append(event_us(candidate_function, candidate_tensors, blocksize, True))
+                baseline_samples.append(event_us(baseline_function, baseline_tensors, blocksize, False))
+            else:
+                baseline_samples.append(event_us(baseline_function, baseline_tensors, blocksize, False))
+                candidate_samples.append(event_us(candidate_function, candidate_tensors, blocksize, True))
+
+    assert torch.equal(baseline_tensors[1], candidate_tensors[1])
+    assert torch.equal(baseline_tensors[2], candidate_tensors[2])
+    result = {
+        "record_type": "direct",
+        "dtype": dtype_name,
+        "quant_type": quant_type,
+        "n": n,
+        "blocksize": blocksize,
+        "warmup": warmup,
+        "rounds": rounds,
+        "repetitions": repetitions,
+        "sample_unit": "us",
+        "bytes_per_call": n * DTYPES[dtype_name].itemsize,
+        "effective_bandwidth_definition": "input tensor bytes divided by CUDA-event kernel latency",
+        **summarize(baseline_samples, candidate_samples, repetitions),
+    }
+    result["baseline_effective_gbps"] = result["bytes_per_call"] / result["baseline_median"] / 1000.0
+    result["candidate_effective_gbps"] = result["bytes_per_call"] / result["candidate_median"] / 1000.0
+    return result
+
+
+@contextmanager
+def baseline_public_quantizers(baseline_library):
+    originals = {}
+    for dtype_name in DTYPES:
+        for quant_type in QUANT_TYPES:
+            suffix = "" if quant_type == "general8" else f"_{quant_type}"
+            stream_name = f"cquantize_blockwise_{dtype_name}{suffix}_with_stream"
+            legacy_function = native_function(baseline_library, dtype_name, quant_type, False)
+            originals[stream_name] = getattr(bnb.cextension.lib, stream_name)
+
+            def legacy_adapter(*arguments, function=legacy_function):
+                function(*arguments[:-1])
+
+            setattr(bnb.cextension.lib, stream_name, legacy_adapter)
+    try:
+        yield
+    finally:
+        for name, function in originals.items():
+            setattr(bnb.cextension.lib, name, function)
+
+
+def quantize_public(tensor: torch.Tensor):
+    return F.quantize_4bit(tensor, blocksize=64, quant_type="nf4", compress_statistics=True)
+
+
+def raw_state_equal(actual, expected) -> bool:
+    if not torch.equal(actual.absmax, expected.absmax):
+        return False
+    if not torch.equal(actual.offset, expected.offset):
+        return False
+    return torch.equal(actual.state2.absmax, expected.state2.absmax)
+
+
+def run_pipeline(
+    variant: str,
+    baseline_library,
+    host_inputs: list[torch.Tensor],
+    device_inputs: list[torch.Tensor],
+    streams: list[torch.cuda.Stream],
+    keep_outputs: bool = False,
+):
+    outputs = []
+    torch.cuda.synchronize()
+    start = time.perf_counter()
+    if variant == "baseline":
+        copy_events = []
+        for host_input, device_input, stream in zip(host_inputs, device_inputs, streams):
+            with torch.cuda.stream(stream):
+                device_input.copy_(host_input, non_blocking=True)
+                event = torch.cuda.Event()
+                event.record()
+                copy_events.append(event)
+        for event in copy_events:
+            event.synchronize()
+        with baseline_public_quantizers(baseline_library):
+            for device_input in device_inputs:
+                outputs.append(quantize_public(device_input))
+    else:
+        for host_input, device_input, stream in zip(host_inputs, device_inputs, streams):
+            with torch.cuda.stream(stream):
+                device_input.copy_(host_input, non_blocking=True)
+                outputs.append(quantize_public(device_input))
+    torch.cuda.synchronize()
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    return (elapsed_ms, outputs) if keep_outputs else elapsed_ms
+
+
+def benchmark_pipeline_case(
+    baseline_library,
+    dtype_name: str,
+    shape: tuple[int, int],
+    warmup: int,
+    rounds: int,
+    repetitions: int,
+) -> dict:
+    dtype = DTYPES[dtype_name]
+    host_inputs = [torch.full(shape, value, dtype=dtype, pin_memory=True) for value in (-0.75, 1.25)]
+    device_inputs = [torch.empty(shape, dtype=dtype, device="cuda") for _ in host_inputs]
+    streams = [torch.cuda.Stream() for _ in host_inputs]
+
+    _, baseline_outputs = run_pipeline(
+        "baseline", baseline_library, host_inputs, device_inputs, streams, keep_outputs=True
+    )
+    _, candidate_outputs = run_pipeline(
+        "candidate", baseline_library, host_inputs, device_inputs, streams, keep_outputs=True
+    )
+    for (baseline_output, baseline_state), (candidate_output, candidate_state) in zip(
+        baseline_outputs, candidate_outputs
+    ):
+        assert torch.equal(baseline_output, candidate_output)
+        assert raw_state_equal(baseline_state, candidate_state)
+
+    for index in range(warmup):
+        order = ("candidate", "baseline") if index % 2 else ("baseline", "candidate")
+        for variant in order:
+            run_pipeline(variant, baseline_library, host_inputs, device_inputs, streams)
+
+    baseline_samples = []
+    candidate_samples = []
+    for round_index in range(rounds):
+        for sample_index in range(repetitions):
+            order = ("candidate", "baseline") if (round_index + sample_index) % 2 else ("baseline", "candidate")
+            for variant in order:
+                elapsed = run_pipeline(variant, baseline_library, host_inputs, device_inputs, streams)
+                if variant == "baseline":
+                    baseline_samples.append(elapsed)
+                else:
+                    candidate_samples.append(elapsed)
+
+    input_bytes = sum(tensor.numel() * tensor.element_size() for tensor in host_inputs)
+    result = {
+        "record_type": "pipeline",
+        "dtype": dtype_name,
+        "shape": list(shape),
+        "quant_type": "nf4",
+        "compress_statistics": True,
+        "streams": len(streams),
+        "warmup": warmup,
+        "rounds": rounds,
+        "repetitions": repetitions,
+        "sample_unit": "ms",
+        "input_bytes_per_sample": input_bytes,
+        "total_timed_input_bytes_per_variant": input_bytes * rounds * repetitions,
+        "effective_bandwidth_definition": "sum of both H2D input byte counts divided by synchronized host wall time",
+        "baseline_serialization": "host waits for both H2D copies, then quantizes on stream 0",
+        "candidate_pipeline": "each nonblocking stream chains H2D copy and public quantize_4bit",
+        **summarize(baseline_samples, candidate_samples, repetitions),
+    }
+    result["baseline_effective_gbps"] = input_bytes / result["baseline_median"] / 1_000_000.0
+    result["candidate_effective_gbps"] = input_bytes / result["candidate_median"] / 1_000_000.0
+    return result
+
+
+def parse_shapes(value: str) -> list[tuple[int, int]]:
+    return [tuple(int(dimension) for dimension in item.lower().split("x")) for item in value.split(",")]
+
+
+def write_record(handle, record: dict) -> None:
+    line = json.dumps(record, sort_keys=True)
+    print(line, flush=True)
+    handle.write(line + "\n")
+    handle.flush()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline-library", type=Path, required=True)
+    parser.add_argument("--candidate-library", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--sizes", default="524288,8388608,67108864,536870912")
+    parser.add_argument("--pipeline-shapes", default="4096x4096,11008x4096,4096x11008")
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--rounds", type=int, default=7)
+    parser.add_argument("--direct-repetitions", type=int, default=100)
+    parser.add_argument("--pipeline-repetitions", type=int, default=15)
+    parser.add_argument("--profile", action="store_true")
+    args = parser.parse_args()
+
+    properties = torch.cuda.get_device_properties(0)
+    assert torch.cuda.get_device_capability(0) == (10, 3)
+    assert "B300" in properties.name.upper()
+    assert properties.multi_processor_count == 148
+
+    baseline_path = args.baseline_library.resolve()
+    candidate_path = args.candidate_library.resolve()
+    loaded_path = Path(bnb.cextension.lib._lib._name).resolve()
+    assert loaded_path == candidate_path, (loaded_path, candidate_path)
+    baseline_library = configure_legacy_library(baseline_path)
+    for dtype_name in DTYPES:
+        for quant_type in QUANT_TYPES:
+            native_function(baseline_library, dtype_name, quant_type, False)
+            native_function(bnb.cextension.lib._lib, dtype_name, quant_type, True)
+
+    metadata = {
+        "record_type": "metadata",
+        "git_revision": os.environ.get("BENCHMARK_GIT_REVISION", "unknown"),
+        "baseline_revision": os.environ.get("BENCHMARK_BASELINE_REVISION", "unknown"),
+        "baseline_library": str(baseline_path),
+        "candidate_library": str(candidate_path),
+        "baseline_library_bytes": baseline_path.stat().st_size,
+        "candidate_library_bytes": candidate_path.stat().st_size,
+        "device": properties.name,
+        "compute_capability": list(torch.cuda.get_device_capability(0)),
+        "num_sms": properties.multi_processor_count,
+        "torch": torch.__version__,
+        "torch_cuda": torch.version.cuda,
+        "cuda_targets": os.environ.get("BENCHMARK_CUDA_TARGETS", "unknown"),
+        "warmup": args.warmup,
+        "rounds": args.rounds,
+        "direct_repetitions": args.direct_repetitions,
+        "pipeline_repetitions": args.pipeline_repetitions,
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        write_record(handle, metadata)
+        if args.profile:
+            shape = parse_shapes(args.pipeline_shapes)[0]
+            dtype = torch.float16
+            host_inputs = [torch.full(shape, value, dtype=dtype, pin_memory=True) for value in (-0.75, 1.25)]
+            device_inputs = [torch.empty(shape, dtype=dtype, device="cuda") for _ in host_inputs]
+            streams = [torch.cuda.Stream() for _ in host_inputs]
+            torch.cuda.nvtx.range_push("serialized_baseline")
+            baseline_ms = run_pipeline("baseline", baseline_library, host_inputs, device_inputs, streams)
+            torch.cuda.nvtx.range_pop()
+            torch.cuda.nvtx.range_push("current_stream_candidate")
+            candidate_ms = run_pipeline("candidate", baseline_library, host_inputs, device_inputs, streams)
+            torch.cuda.nvtx.range_pop()
+            write_record(
+                handle,
+                {
+                    "record_type": "profile",
+                    "shape": list(shape),
+                    "baseline_ms": baseline_ms,
+                    "candidate_ms": candidate_ms,
+                },
+            )
+            return
+
+        sizes = [int(value) for value in args.sizes.split(",")]
+        for dtype_name in DTYPES:
+            for quant_type in QUANT_TYPES:
+                for n in sizes:
+                    repetitions = direct_repetitions(n, args.direct_repetitions)
+                    result = benchmark_direct_case(
+                        baseline_library,
+                        bnb.cextension.lib._lib,
+                        dtype_name,
+                        quant_type,
+                        n,
+                        64,
+                        args.warmup,
+                        args.rounds,
+                        repetitions,
+                    )
+                    write_record(handle, result)
+
+        for dtype_name in ("fp16", "bf16"):
+            for shape in parse_shapes(args.pipeline_shapes):
+                result = benchmark_pipeline_case(
+                    baseline_library,
+                    dtype_name,
+                    shape,
+                    args.warmup,
+                    args.rounds,
+                    args.pipeline_repetitions,
+                )
+                write_record(handle, result)
+
+
+if __name__ == "__main__":
+    main()

--- a/bitsandbytes/backends/cuda/ops.py
+++ b/bitsandbytes/backends/cuda/ops.py
@@ -58,11 +58,18 @@ _setup_ctypes(
     [ct.c_void_p] * 3 + [ct.c_float, ct.c_int32, ct.c_int32, ct.c_void_p],
 )
 
-# 4-bit/8-bit blockwise quantize: (code, A, absmax, out, blocksize, n)
+# Legacy 4-bit/8-bit blockwise quantize: (code, A, absmax, out, blocksize, n)
 _setup_ctypes(
     [f"cquantize_blockwise_{d}_{q}" for d in ("fp32", "bf16", "fp16") for q in ("nf4", "fp4")]
     + [f"cquantize_blockwise_{d}" for d in ("fp32", "bf16", "fp16")],
     [ct.c_void_p] * 4 + [ct.c_int32, ct.c_int32],
+)
+
+# 4-bit/8-bit blockwise quantize: (code, A, absmax, out, blocksize, n, stream)
+_setup_ctypes(
+    [f"cquantize_blockwise_{d}_{q}_with_stream" for d in ("fp32", "bf16", "fp16") for q in ("nf4", "fp4")]
+    + [f"cquantize_blockwise_{d}_with_stream" for d in ("fp32", "bf16", "fp16")],
+    [ct.c_void_p] * 4 + [ct.c_int32, ct.c_int32, ct.c_void_p],
 )
 
 
@@ -311,11 +318,11 @@ def _(A: torch.Tensor, code: torch.Tensor, blocksize: int) -> tuple[torch.Tensor
     out = torch.empty_like(A, dtype=torch.uint8)
 
     if A.dtype == torch.float32:
-        fn = lib.cquantize_blockwise_fp32
+        fn = lib.cquantize_blockwise_fp32_with_stream
     elif A.dtype == torch.float16:
-        fn = lib.cquantize_blockwise_fp16
+        fn = lib.cquantize_blockwise_fp16_with_stream
     elif A.dtype == torch.bfloat16:
-        fn = lib.cquantize_blockwise_bf16
+        fn = lib.cquantize_blockwise_bf16_with_stream
     else:
         raise ValueError(f"Blockwise quantization only supports 16/32-bit floats, but got {A.dtype}")
 
@@ -327,6 +334,7 @@ def _(A: torch.Tensor, code: torch.Tensor, blocksize: int) -> tuple[torch.Tensor
             out.data_ptr(),
             blocksize,
             n,
+            _get_raw_stream(A.device.index),
         )
 
     return out, absmax
@@ -393,19 +401,19 @@ def _(
 
     if A.dtype == torch.bfloat16:
         if quant_type == "fp4":
-            fn = lib.cquantize_blockwise_bf16_fp4
+            fn = lib.cquantize_blockwise_bf16_fp4_with_stream
         else:
-            fn = lib.cquantize_blockwise_bf16_nf4
+            fn = lib.cquantize_blockwise_bf16_nf4_with_stream
     elif A.dtype == torch.float16:
         if quant_type == "fp4":
-            fn = lib.cquantize_blockwise_fp16_fp4
+            fn = lib.cquantize_blockwise_fp16_fp4_with_stream
         else:
-            fn = lib.cquantize_blockwise_fp16_nf4
+            fn = lib.cquantize_blockwise_fp16_nf4_with_stream
     elif A.dtype == torch.float32:
         if quant_type == "fp4":
-            fn = lib.cquantize_blockwise_fp32_fp4
+            fn = lib.cquantize_blockwise_fp32_fp4_with_stream
         else:
-            fn = lib.cquantize_blockwise_fp32_nf4
+            fn = lib.cquantize_blockwise_fp32_nf4_with_stream
 
     with _cuda_device_of(A):
         fn(
@@ -415,6 +423,7 @@ def _(
             out.data_ptr(),
             blocksize,
             n,
+            _get_raw_stream(A.device.index),
         )
 
     return out, absmax

--- a/csrc/ops.cu
+++ b/csrc/ops.cu
@@ -35,39 +35,48 @@ using std::endl;
 
 template <typename T, int STOCHASTIC, int DATA_TYPE>
 void quantizeBlockwise(
-    float* code, T* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n
+    float* code, T* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n,
+    bnb_stream_t stream
 ) {
     int num_blocks = n / blocksize;
     num_blocks = n % blocksize == 0 ? num_blocks : num_blocks + 1;
 
     if (blocksize == 4096)
         kQuantizeBlockwise<T, 4096, 4, STOCHASTIC, DATA_TYPE>
-            <<<num_blocks, 1024>>>(code, A, absmax, out, rand, rand_offset, n);
+            <<<num_blocks, 1024, 0, stream>>>(code, A, absmax, out, rand, rand_offset, n);
     else if (blocksize == 2048)
-        kQuantizeBlockwise<T, 2048, 4, 0, DATA_TYPE><<<num_blocks, 512>>>(code, A, absmax, out, rand, rand_offset, n);
+        kQuantizeBlockwise<T, 2048, 4, 0, DATA_TYPE>
+            <<<num_blocks, 512, 0, stream>>>(code, A, absmax, out, rand, rand_offset, n);
     else if (blocksize == 1024)
-        kQuantizeBlockwise<T, 1024, 4, 0, DATA_TYPE><<<num_blocks, 256>>>(code, A, absmax, out, rand, rand_offset, n);
+        kQuantizeBlockwise<T, 1024, 4, 0, DATA_TYPE>
+            <<<num_blocks, 256, 0, stream>>>(code, A, absmax, out, rand, rand_offset, n);
     else if (blocksize == 512)
-        kQuantizeBlockwise<T, 512, 2, 0, DATA_TYPE><<<num_blocks, 256>>>(code, A, absmax, out, rand, rand_offset, n);
+        kQuantizeBlockwise<T, 512, 2, 0, DATA_TYPE>
+            <<<num_blocks, 256, 0, stream>>>(code, A, absmax, out, rand, rand_offset, n);
     else if (blocksize == 256)
-        kQuantizeBlockwise<T, 256, 2, 0, DATA_TYPE><<<num_blocks, 128>>>(code, A, absmax, out, rand, rand_offset, n);
+        kQuantizeBlockwise<T, 256, 2, 0, DATA_TYPE>
+            <<<num_blocks, 128, 0, stream>>>(code, A, absmax, out, rand, rand_offset, n);
     else if (blocksize == 128)
-        kQuantizeBlockwise<T, 128, 2, 0, DATA_TYPE><<<num_blocks, 64>>>(code, A, absmax, out, rand, rand_offset, n);
+        kQuantizeBlockwise<T, 128, 2, 0, DATA_TYPE>
+            <<<num_blocks, 64, 0, stream>>>(code, A, absmax, out, rand, rand_offset, n);
     else if (blocksize == 64) {
         if constexpr (DATA_TYPE > 0) {
             const int ws = bnb_host_warp_size();
             const int num_qb = ws / (64 / 2);
             int grid = (num_blocks + num_qb - 1) / num_qb;
-            kQuantizeBlockwiseSmall<T, 64, DATA_TYPE><<<grid, ws>>>(code, A, absmax, out, rand, rand_offset, n);
+            kQuantizeBlockwiseSmall<T, 64, DATA_TYPE>
+                <<<grid, ws, 0, stream>>>(code, A, absmax, out, rand, rand_offset, n);
         } else {
-            kQuantizeBlockwise<T, 64, 2, 0, DATA_TYPE><<<num_blocks, 32>>>(code, A, absmax, out, rand, rand_offset, n);
+            kQuantizeBlockwise<T, 64, 2, 0, DATA_TYPE>
+                <<<num_blocks, 32, 0, stream>>>(code, A, absmax, out, rand, rand_offset, n);
         }
     } else if (blocksize == 32) {
         if constexpr (DATA_TYPE > 0) {
             const int ws = bnb_host_warp_size();
             const int num_qb = ws / (32 / 2);
             int grid = (num_blocks + num_qb - 1) / num_qb;
-            kQuantizeBlockwiseSmall<T, 32, DATA_TYPE><<<grid, ws>>>(code, A, absmax, out, rand, rand_offset, n);
+            kQuantizeBlockwiseSmall<T, 32, DATA_TYPE>
+                <<<grid, ws, 0, stream>>>(code, A, absmax, out, rand, rand_offset, n);
         }
     }
 
@@ -495,44 +504,52 @@ template int igemmlt<8, 1>(
 );
 
 template void quantizeBlockwise<half, 1, General8bit>(
-    float* code, half* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n
+    float* code, half* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n,
+    bnb_stream_t stream
 );
 template void quantizeBlockwise<half, 0, General8bit>(
-    float* code, half* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n
+    float* code, half* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n,
+    bnb_stream_t stream
 );
 template void quantizeBlockwise<half, 0, FP4>(
-    float* code, half* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n
+    float* code, half* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n,
+    bnb_stream_t stream
 );
 template void quantizeBlockwise<half, 0, NF4>(
-    float* code, half* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n
+    float* code, half* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n,
+    bnb_stream_t stream
 );
 template void quantizeBlockwise<float, 1, General8bit>(
-    float* code, float* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n
+    float* code, float* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n,
+    bnb_stream_t stream
 );
 template void quantizeBlockwise<float, 0, General8bit>(
-    float* code, float* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n
+    float* code, float* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n,
+    bnb_stream_t stream
 );
 template void quantizeBlockwise<float, 0, FP4>(
-    float* code, float* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n
+    float* code, float* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n,
+    bnb_stream_t stream
 );
 template void quantizeBlockwise<float, 0, NF4>(
-    float* code, float* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n
+    float* code, float* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n,
+    bnb_stream_t stream
 );
 template void quantizeBlockwise<bnb_bfloat16, 1, General8bit>(
     float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize,
-    const int n
+    const int n, bnb_stream_t stream
 );
 template void quantizeBlockwise<bnb_bfloat16, 0, General8bit>(
     float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize,
-    const int n
+    const int n, bnb_stream_t stream
 );
 template void quantizeBlockwise<bnb_bfloat16, 0, FP4>(
     float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize,
-    const int n
+    const int n, bnb_stream_t stream
 );
 template void quantizeBlockwise<bnb_bfloat16, 0, NF4>(
     float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize,
-    const int n
+    const int n, bnb_stream_t stream
 );
 
 template void dequantizeBlockwise<float, General8bit>(

--- a/csrc/ops.cuh
+++ b/csrc/ops.cuh
@@ -94,7 +94,8 @@ class ContextLt {
 
 template <typename T, int STOCHASTIC, int DATA_TYPE>
 void quantizeBlockwise(
-    float* code, T* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n
+    float* code, T* A, float* absmax, unsigned char* out, float* rand, int rand_offset, int blocksize, const int n,
+    bnb_stream_t stream
 );
 template <typename T, int DATA_TYPE>
 void dequantizeBlockwise(

--- a/csrc/pythonInterface.cpp
+++ b/csrc/pythonInterface.cpp
@@ -124,46 +124,58 @@ MAKE_BLOCKWISE8(ademamix, ADEMAMIX, half, fp16)
 MAKE_BLOCKWISE8(ademamix, ADEMAMIX, bnb_bfloat16, bf16)
 MAKE_BLOCKWISE8(ademamix, ADEMAMIX, float, fp32)
 
-void quantizeBlockwise_fp16(float* code, half* A, float* absmax, unsigned char* out, int blocksize, const int n) {
-    quantizeBlockwise<half, 0, General8bit>(code, A, absmax, out, nullptr, 0, blocksize, n);
+void quantizeBlockwise_fp16(
+    float* code, half* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise<half, 0, General8bit>(code, A, absmax, out, nullptr, 0, blocksize, n, stream);
 }
 
-void quantizeBlockwise_fp16_fp4(float* code, half* A, float* absmax, unsigned char* out, int blocksize, const int n) {
-    quantizeBlockwise<half, 0, FP4>(nullptr, A, absmax, out, nullptr, 0, blocksize, n);
+void quantizeBlockwise_fp16_fp4(
+    float* code, half* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise<half, 0, FP4>(nullptr, A, absmax, out, nullptr, 0, blocksize, n, stream);
 }
 
-void quantizeBlockwise_fp16_nf4(float* code, half* A, float* absmax, unsigned char* out, int blocksize, const int n) {
-    quantizeBlockwise<half, 0, NF4>(nullptr, A, absmax, out, nullptr, 0, blocksize, n);
+void quantizeBlockwise_fp16_nf4(
+    float* code, half* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise<half, 0, NF4>(nullptr, A, absmax, out, nullptr, 0, blocksize, n, stream);
 }
 
 void quantizeBlockwise_bf16(
-    float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, int blocksize, const int n
+    float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
 ) {
-    quantizeBlockwise<bnb_bfloat16, 0, General8bit>(code, A, absmax, out, nullptr, 0, blocksize, n);
+    quantizeBlockwise<bnb_bfloat16, 0, General8bit>(code, A, absmax, out, nullptr, 0, blocksize, n, stream);
 }
 
 void quantizeBlockwise_bf16_fp4(
-    float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, int blocksize, const int n
+    float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
 ) {
-    quantizeBlockwise<bnb_bfloat16, 0, FP4>(nullptr, A, absmax, out, nullptr, 0, blocksize, n);
+    quantizeBlockwise<bnb_bfloat16, 0, FP4>(nullptr, A, absmax, out, nullptr, 0, blocksize, n, stream);
 }
 
 void quantizeBlockwise_bf16_nf4(
-    float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, int blocksize, const int n
+    float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
 ) {
-    quantizeBlockwise<bnb_bfloat16, 0, NF4>(nullptr, A, absmax, out, nullptr, 0, blocksize, n);
+    quantizeBlockwise<bnb_bfloat16, 0, NF4>(nullptr, A, absmax, out, nullptr, 0, blocksize, n, stream);
 }
 
-void quantizeBlockwise_fp32(float* code, float* A, float* absmax, unsigned char* out, int blocksize, const int n) {
-    quantizeBlockwise<float, 0, General8bit>(code, A, absmax, out, nullptr, 0, blocksize, n);
+void quantizeBlockwise_fp32(
+    float* code, float* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise<float, 0, General8bit>(code, A, absmax, out, nullptr, 0, blocksize, n, stream);
 }
 
-void quantizeBlockwise_fp32_fp4(float* code, float* A, float* absmax, unsigned char* out, int blocksize, const int n) {
-    quantizeBlockwise<float, 0, FP4>(nullptr, A, absmax, out, nullptr, 0, blocksize, n);
+void quantizeBlockwise_fp32_fp4(
+    float* code, float* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise<float, 0, FP4>(nullptr, A, absmax, out, nullptr, 0, blocksize, n, stream);
 }
 
-void quantizeBlockwise_fp32_nf4(float* code, float* A, float* absmax, unsigned char* out, int blocksize, const int n) {
-    quantizeBlockwise<float, 0, NF4>(nullptr, A, absmax, out, nullptr, 0, blocksize, n);
+void quantizeBlockwise_fp32_nf4(
+    float* code, float* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise<float, 0, NF4>(nullptr, A, absmax, out, nullptr, 0, blocksize, n, stream);
 }
 
 void dequantizeBlockwise_fp16(
@@ -362,31 +374,67 @@ void cdequantize_blockwise_fp16_nf4(
 }
 
 void cquantize_blockwise_fp16(float* code, half* A, float* absmax, unsigned char* out, int blocksize, const int n) {
-    quantizeBlockwise_fp16(code, A, absmax, out, blocksize, n);
+    quantizeBlockwise_fp16(code, A, absmax, out, blocksize, n, nullptr);
+}
+
+void cquantize_blockwise_fp16_with_stream(
+    float* code, half* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise_fp16(code, A, absmax, out, blocksize, n, stream);
 }
 
 void cquantize_blockwise_fp16_fp4(float* code, half* A, float* absmax, unsigned char* out, int blocksize, const int n) {
-    quantizeBlockwise_fp16_fp4(code, A, absmax, out, blocksize, n);
+    quantizeBlockwise_fp16_fp4(code, A, absmax, out, blocksize, n, nullptr);
+}
+
+void cquantize_blockwise_fp16_fp4_with_stream(
+    float* code, half* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise_fp16_fp4(code, A, absmax, out, blocksize, n, stream);
 }
 
 void cquantize_blockwise_fp16_nf4(float* code, half* A, float* absmax, unsigned char* out, int blocksize, const int n) {
-    quantizeBlockwise_fp16_nf4(code, A, absmax, out, blocksize, n);
+    quantizeBlockwise_fp16_nf4(code, A, absmax, out, blocksize, n, nullptr);
+}
+
+void cquantize_blockwise_fp16_nf4_with_stream(
+    float* code, half* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise_fp16_nf4(code, A, absmax, out, blocksize, n, stream);
 }
 
 void cquantize_blockwise_fp32(float* code, float* A, float* absmax, unsigned char* out, int blocksize, const int n) {
-    quantizeBlockwise_fp32(code, A, absmax, out, blocksize, n);
+    quantizeBlockwise_fp32(code, A, absmax, out, blocksize, n, nullptr);
+}
+
+void cquantize_blockwise_fp32_with_stream(
+    float* code, float* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise_fp32(code, A, absmax, out, blocksize, n, stream);
 }
 
 void cquantize_blockwise_fp32_fp4(
     float* code, float* A, float* absmax, unsigned char* out, int blocksize, const int n
 ) {
-    quantizeBlockwise_fp32_fp4(code, A, absmax, out, blocksize, n);
+    quantizeBlockwise_fp32_fp4(code, A, absmax, out, blocksize, n, nullptr);
+}
+
+void cquantize_blockwise_fp32_fp4_with_stream(
+    float* code, float* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise_fp32_fp4(code, A, absmax, out, blocksize, n, stream);
 }
 
 void cquantize_blockwise_fp32_nf4(
     float* code, float* A, float* absmax, unsigned char* out, int blocksize, const int n
 ) {
-    quantizeBlockwise_fp32_nf4(code, A, absmax, out, blocksize, n);
+    quantizeBlockwise_fp32_nf4(code, A, absmax, out, blocksize, n, nullptr);
+}
+
+void cquantize_blockwise_fp32_nf4_with_stream(
+    float* code, float* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise_fp32_nf4(code, A, absmax, out, blocksize, n, stream);
 }
 
 void cdequantize_blockwise_fp32(
@@ -410,19 +458,37 @@ void cdequantize_blockwise_fp32_nf4(
 void cquantize_blockwise_bf16(
     float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, int blocksize, const int n
 ) {
-    quantizeBlockwise_bf16(code, A, absmax, out, blocksize, n);
+    quantizeBlockwise_bf16(code, A, absmax, out, blocksize, n, nullptr);
+}
+
+void cquantize_blockwise_bf16_with_stream(
+    float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise_bf16(code, A, absmax, out, blocksize, n, stream);
 }
 
 void cquantize_blockwise_bf16_fp4(
     float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, int blocksize, const int n
 ) {
-    quantizeBlockwise_bf16_fp4(code, A, absmax, out, blocksize, n);
+    quantizeBlockwise_bf16_fp4(code, A, absmax, out, blocksize, n, nullptr);
+}
+
+void cquantize_blockwise_bf16_fp4_with_stream(
+    float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise_bf16_fp4(code, A, absmax, out, blocksize, n, stream);
 }
 
 void cquantize_blockwise_bf16_nf4(
     float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, int blocksize, const int n
 ) {
-    quantizeBlockwise_bf16_nf4(code, A, absmax, out, blocksize, n);
+    quantizeBlockwise_bf16_nf4(code, A, absmax, out, blocksize, n, nullptr);
+}
+
+void cquantize_blockwise_bf16_nf4_with_stream(
+    float* code, bnb_bfloat16* A, float* absmax, unsigned char* out, int blocksize, const int n, cudaStream_t stream
+) {
+    quantizeBlockwise_bf16_nf4(code, A, absmax, out, blocksize, n, stream);
 }
 
 void cdequantize_blockwise_bf16(

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -375,6 +375,68 @@ class Test4bitBlockwiseQuantOps:
         torch.testing.assert_close(out, ref)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.skipif(torch.version.hip is not None, reason="This regression test uses torch.cuda._sleep")
+class TestBlockwiseQuantizeCurrentStream:
+    @staticmethod
+    def _quantize(kind, A):
+        if kind == "general8":
+            return bitsandbytes.functional.quantize_blockwise(A, blocksize=64)
+        if kind == "general8_nested":
+            return bitsandbytes.functional.quantize_blockwise(A, blocksize=64, nested=True)
+        if kind == "nf4":
+            return bitsandbytes.functional.quantize_4bit(A, blocksize=64, quant_type="nf4")
+        if kind == "nf4_nested":
+            return bitsandbytes.functional.quantize_4bit(A, blocksize=64, quant_type="nf4", compress_statistics=True)
+        raise ValueError(kind)
+
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32], ids=describe_dtype)
+    @pytest.mark.parametrize("kind", ["general8", "general8_nested", "nf4", "nf4_nested"])
+    def test_quantize_respects_current_stream(self, dtype, kind):
+        stale = torch.zeros(4096 + 17, device="cuda", dtype=dtype)
+        expected_input = torch.linspace(-3.0, 5.0, stale.numel(), device="cuda", dtype=torch.float32).to(dtype)
+        torch.cuda.synchronize()
+
+        expected_output, expected_state = self._quantize(kind, expected_input)
+        torch.cuda.synchronize()
+
+        blocker = torch.cuda.Stream()
+        stream = torch.cuda.Stream()
+        gate = torch.cuda.Event()
+        with torch.cuda.stream(blocker):
+            torch.cuda._sleep(200_000_000)
+            gate.record()
+
+        assert not gate.query()
+        with torch.cuda.stream(stream):
+            stream.wait_event(gate)
+            stale.copy_(expected_input)
+            output, state = self._quantize(kind, stale)
+
+        torch.cuda.synchronize()
+        assert torch.equal(stale, expected_input)
+        assert torch.equal(output, expected_output)
+        assert torch.equal(state.absmax, expected_state.absmax)
+        if expected_state.offset is None:
+            assert state.offset is None
+        else:
+            assert torch.equal(state.offset, expected_state.offset)
+        if expected_state.state2 is None:
+            assert state.state2 is None
+        else:
+            assert torch.equal(state.state2.absmax, expected_state.state2.absmax)
+
+    def test_quantize_stream_symbols_preserve_legacy_abi(self):
+        for dtype in ("fp16", "bf16", "fp32"):
+            for suffix in ("", "_fp4", "_nf4"):
+                legacy_name = f"cquantize_blockwise_{dtype}{suffix}"
+                stream_name = f"{legacy_name}_with_stream"
+                getattr(bitsandbytes.cextension.lib._lib, legacy_name)
+                getattr(bitsandbytes.cextension.lib._lib, stream_name)
+                assert len(getattr(bitsandbytes.cextension.lib, legacy_name).argtypes) == 6
+                assert len(getattr(bitsandbytes.cextension.lib, stream_name).argtypes) == 7
+
+
 class TestNonContiguousInputs:
     """Regression tests for #1342 and #1690: quantization must handle non-contiguous tensors correctly."""
 


### PR DESCRIPTION
## Summary

Blockwise CUDA quantization currently launches on the legacy default stream even when PyTorch has selected a different current stream. This can let quantization run before a producer on that current stream has finished writing its input.

This change:

- adds stream-aware native entry points for General8, FP4, and NF4 blockwise quantization;
- passes PyTorch's current raw CUDA stream from both registered CUDA quantization operations;
- threads that stream through every existing block-size launch from 32 through 4096;
- preserves every existing six-argument C symbol and its stream-0 behavior for ABI compatibility; and
- adds a focused ordering regression test and a reproducible B300 benchmark CLI.

The public schema, Python API, output allocation, launch geometry, quantization math, and existing C ABI are unchanged.

Tracking:

- Fork issue: https://github.com/heiheiha798/bitsandbytes/issues/18
- Fork draft PR and engineering record: https://github.com/heiheiha798/bitsandbytes/pull/19

## Reproduced failure

Slurm job 5099 built the exact baseline `95f9af309d4d5793847169c39288dcd3fcbdf564` for the official CUDA 13 x64 target input `75;80;86;89;90;100;120` and ran on one NVIDIA B300 SXM6 AC (CC 10.3, 148 SMs).

The reproducer recorded a pending blocker event before entering the test stream, made that stream wait, filled the input there, and immediately called the public quantizer. All four baseline paths read stale data while the final input itself was correct:

- direct General8 blockwise quantization;
- nested General8 blockwise quantization;
- direct NF4 quantization; and
- compressed-statistics NF4 quantization.

Archived evidence is listed in the linked fork draft PR.

## Correctness and safety

Slurm job 5101 built production/test commit `86aabee18f42d54448e26cb281aea8fe083b8b16` with the same official-compatible target list and asserted the loaded temporary library path.

- 345/345 raw-bit parity cells passed between the preserved legacy entry points and the new stream-aware entry points.
- Coverage included FP16/BF16/FP32, General8/FP4/NF4, every supported block size from 32 through 4096, full blocks, and tails.
- 73 focused ops cases passed with 30 known storage-dtype opcheck xfails.
- 144 focused functional cases passed.
- `compute-sanitizer --tool racecheck`: 0 hazards, 0 errors, 0 warnings.
- `compute-sanitizer --tool synccheck`: 0 errors.

The final head `56d8d94082568e7d6a8c0788e4247583cdbb65d5` changes only the tracked benchmark after that production/test commit. Job 5104 separately built and loaded that exact final head and rechecked bitwise equality throughout the benchmark matrix.

CPU collection also remains healthy: 33 passed, 22 CUDA-only skips, 345 deselected. Full `pre-commit run --all-files` passes.

## B300 measurement

Job 5104 built isolated baseline and candidate source trees with CUDA 13.0.88 and the official-compatible targets, asserted both native library paths, and measured on the same B300 allocation. The tracked CLI interleaves variants after 20 warmups for 7 rounds, retaining every sample, per-round medians, p10/p90, bootstrap ratio intervals, and input-byte effective bandwidth.

Default-stream direct latency covered 36 cells: FP16/BF16/FP32 x General8/FP4/NF4 x `n={524288,8388608,67108864,536870912}` elements. Those counts are 1 MiB, 16 MiB, 128 MiB, and 1 GiB for FP16/BF16 inputs, and 2 MiB, 32 MiB, 256 MiB, and 2 GiB for FP32 inputs. The worst baseline/candidate ratio was `0.98310`, equivalent to a 1.72% candidate slowdown, so the <=2% regression gate passed.

The correct two-stream pinned-H2D plus compressed-NF4 pipeline covered six cells. The baseline explicitly waits for both copies before stream-0 quantization; the candidate chains each copy and public quantizer on its current stream.

| dtype | shape | baseline ms | candidate ms | ratio | 95% ratio interval |
|---|---:|---:|---:|---:|---:|
| FP16 | 4096x4096 | 1.6109 | 1.5937 | 1.0108x | [1.0091, 1.0121] |
| FP16 | 11008x4096 | 4.0615 | 4.0386 | 1.0057x | [1.0047, 1.0063] |
| FP16 | 4096x11008 | 4.0521 | 4.0332 | 1.0047x | [1.0041, 1.0053] |
| BF16 | 4096x4096 | 1.6333 | 1.6175 | 1.0098x | [1.0086, 1.0106] |
| BF16 | 11008x4096 | 4.0723 | 4.0497 | 1.0056x | [1.0049, 1.0060] |
| BF16 | 4096x11008 | 4.1249 | 4.1045 | 1.0050x | [1.0045, 1.0065] |

These gains are 0.47%-1.08%, below the 5% performance-claim threshold. This PR is therefore a correctness fix and makes no B300 speedup claim. Nsight Systems confirms H2D and quantization activity in the serialized-baseline and current-stream-candidate ranges; its one-shot range durations include setup and are not used as performance claims.

Archived evidence is listed in the linked fork draft PR.

## Reproduction

After building baseline and candidate into isolated source trees with the CUDA 13 x64 target list, run:

```bash
export PYTHONPATH=/tmp/bnb-quant-stream/source-candidate
export BENCHMARK_BASELINE_REVISION=95f9af309d4d5793847169c39288dcd3fcbdf564
export BENCHMARK_GIT_REVISION=56d8d94082568e7d6a8c0788e4247583cdbb65d5
export BENCHMARK_CUDA_TARGETS='75;80;86;89;90;100;120'

python /tmp/bnb-quant-stream/source-candidate/benchmarking/quantize_blockwise_stream.py \
  --baseline-library /tmp/bnb-quant-stream/source-baseline/bitsandbytes/libbitsandbytes_cuda130.so \
  --candidate-library /tmp/bnb-quant-stream/source-candidate/bitsandbytes/libbitsandbytes_cuda130.so \
  --output /tmp/quantize-blockwise-stream.jsonl \
  --warmup 20 \
  --rounds 7 \
  --direct-repetitions 100 \
  --pipeline-repetitions 15
```

The exact build and invocation transcript is listed in the linked fork draft PR.

## Limitations

- Fixed-shape CUDA graph capture was attempted, but the existing public path copies the quantization code map from CPU to CUDA during capture. PyTorch rejects that pre-existing allocation/copy surface. This PR does not add an out schema or memory-management redesign.
- Neither the login environment nor the Slurm B300 environment provides ROCm/`hipcc`, so HIP compile/runtime validation was unavailable. The shared source remains syntactically scoped through the existing CUDA/HIP stream compatibility layer, but downstream HIP CI is required.
- CUDA targets other than CC10.3 were compiled but not executed on their hardware.
- The fork does not run upstream GitHub checks; upstream CI remains required before merge.
