### PR TITLE
Tune SM103 fused 4-bit GEMM SIMT dispatch

### DIFF
--- a/benchmarking/gemm_4bit_sm103_simt_mma.py
+++ b/benchmarking/gemm_4bit_sm103_simt_mma.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Benchmark SM103 fused 4-bit GEMM SIMT, MMA, and automatic dispatch.
 
-This CLI builds three native SM103 libraries from the current commit. The SIMT
-and MMA forcing edits are applied only to temporary source copies. Measurements
-rotate variant order for every sample and are written as JSONL.
+This CLI builds three SM103-compatible libraries from the current commit. The
+SIMT and MMA forcing edits are applied only to temporary source copies.
+Measurements rotate variant order for every sample and are written as JSONL.
 """
 
 import argparse
@@ -15,6 +15,7 @@ from pathlib import Path
 import socket
 import statistics
 import subprocess
+import sys
 
 import torch
 
@@ -30,6 +31,8 @@ CALIBRATION_CASES = (
     ("wave3_below_tall", 28352, 32768, (3, 4, 5, 6, 7, 8)),
     ("wave3_at_tall", 28416, 32768, (3, 4, 5, 6, 7, 8)),
     ("wave3_above_tall", 28480, 32768, (3, 4, 5, 6, 7, 8)),
+    ("wave4_tall_k49152", 37888, 49152, (3, 4, 5, 6, 7, 8)),
+    ("wave8_tall_k81920", 75776, 81920, (3, 4, 5, 6, 7, 8)),
     ("vocab_128256x4096", 128256, 4096, (3, 4, 5, 6, 7, 8)),
 )
 DTYPES = {"fp16": torch.float16, "bf16": torch.bfloat16}
@@ -69,6 +72,11 @@ def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--build-root", required=True, type=Path)
+    parser.add_argument(
+        "--compute-capability",
+        default="103",
+        help="CMake COMPUTE_CAPABILITY target list; defaults to a native SM103 build",
+    )
     parser.add_argument("--warmup", type=positive_int, default=20)
     parser.add_argument("--repetitions", type=positive_int, default=100)
     parser.add_argument("--rounds", type=positive_int, default=7)
@@ -129,14 +137,14 @@ def force_variant(source_root, variant):
         raise ValueError(variant)
 
 
-def build_library(source_root, build_root):
+def build_library(source_root, build_root, compute_capability):
     run(
         [
             "cmake",
             "-G",
             "Ninja",
             "-DCOMPUTE_BACKEND=cuda",
-            "-DCOMPUTE_CAPABILITY=103",
+            f"-DCOMPUTE_CAPABILITY={compute_capability}",
             "-DCMAKE_BUILD_TYPE=Release",
             "-S",
             source_root,
@@ -148,19 +156,19 @@ def build_library(source_root, build_root):
     run(["cmake", "--build", build_root, "--parallel", str(parallel)])
 
 
-def prepare_libraries(repo_root, build_root):
+def prepare_libraries(repo_root, build_root, compute_capability):
     if build_root.exists():
         raise FileExistsError(f"build root must not exist: {build_root}")
     build_root.mkdir(parents=True)
     sources = {}
-    for variant in ("simt", "mma"):
+    for variant in VARIANTS:
         source_root = build_root / f"source-{variant}"
         extract_source(repo_root, source_root)
-        force_variant(source_root, variant)
-        build_library(source_root, build_root / f"build-{variant}")
+        if variant != "automatic":
+            force_variant(source_root, variant)
+        build_library(source_root, build_root / f"build-{variant}", compute_capability)
         sources[variant] = source_root
 
-    build_library(repo_root, build_root / "build-automatic")
     cuda_version = "".join(torch.version.cuda.split(".")[:2])
     libraries = {
         variant: source_root / "bitsandbytes" / f"libbitsandbytes_cuda{cuda_version}.so"
@@ -169,7 +177,7 @@ def prepare_libraries(repo_root, build_root):
     for path in libraries.values():
         if not path.is_file():
             raise FileNotFoundError(path)
-    return libraries
+    return sources, libraries
 
 
 def load_library(path):
@@ -358,13 +366,25 @@ def main():
     commit = subprocess.run(
         ["git", "rev-parse", "HEAD"], cwd=repo_root, check=True, capture_output=True, text=True
     ).stdout.strip()
-    libraries_paths = prepare_libraries(repo_root, args.build_root.resolve())
+    source_roots, library_paths = prepare_libraries(
+        repo_root,
+        args.build_root.resolve(),
+        args.compute_capability,
+    )
 
+    sys.path.insert(0, str(source_roots["automatic"]))
     import bitsandbytes
     from bitsandbytes import functional
     from bitsandbytes.backends.cuda.ops import _gemm_4bit_use_custom_cuda
 
-    libraries = {variant: load_library(path) for variant, path in libraries_paths.items()}
+    automatic_library_name = getattr(getattr(bitsandbytes.cextension.lib, "_lib", None), "_name", None)
+    if not automatic_library_name:
+        raise RuntimeError("automatic bitsandbytes native library path is unavailable")
+    automatic_library = Path(automatic_library_name).resolve()
+    if automatic_library != library_paths["automatic"].resolve():
+        raise RuntimeError(f"expected automatic library {library_paths['automatic']}, loaded {automatic_library}")
+
+    libraries = {variant: load_library(library_paths[variant]) for variant in ("simt", "mma")}
     entrypoints = {
         variant: ct.cast(library.cgemm_4bit_fp16, ct.c_void_p).value for variant, library in libraries.items()
     }
@@ -388,9 +408,10 @@ def main():
         "torch": torch.__version__,
         "torch_cuda": torch.version.cuda,
         "bitsandbytes": bitsandbytes.__version__,
-        "automatic_library": str(getattr(getattr(bitsandbytes.cextension.lib, "_lib", None), "_name", None)),
-        "forced_libraries": {variant: str(path) for variant, path in libraries_paths.items()},
+        "automatic_library": str(automatic_library),
+        "forced_libraries": {variant: str(library_paths[variant]) for variant in ("simt", "mma")},
         "forced_entrypoints_distinct": True,
+        "compute_capability_targets": args.compute_capability,
         "cases": [{"name": name, "n": n, "k": k, "m_values": list(m_values)} for name, n, k, m_values in cases],
         "dtypes": list(dtype_names),
         "warmup": args.warmup,

--- a/benchmarking/gemm_4bit_sm103_simt_mma.py
+++ b/benchmarking/gemm_4bit_sm103_simt_mma.py
@@ -286,7 +286,7 @@ def automatic_internal_path(m, n, k, num_sms):
         return "simt"
     blocks = ((m + 31) // 32) * ((n + 63) // 64)
     undersubscribed = (m <= 8 and blocks * 3 <= num_sms * 2) or (m == 4 and blocks <= num_sms)
-    sm103_tall_k_simt = k > n and m <= 5 and blocks >= num_sms * 3
+    sm103_tall_k_simt = k > n and m <= 5 and num_sms * 3 <= blocks < num_sms * 4
     use_simt = (
         undersubscribed
         or sm103_tall_k_simt

--- a/benchmarking/gemm_4bit_sm103_simt_mma.py
+++ b/benchmarking/gemm_4bit_sm103_simt_mma.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Benchmark SM103 fused 4-bit GEMM SIMT, MMA, and automatic dispatch.
+
+This CLI builds three native SM103 libraries from the current commit. The SIMT
+and MMA forcing edits are applied only to temporary source copies. Measurements
+rotate variant order for every sample and are written as JSONL.
+"""
+
+import argparse
+import ctypes as ct
+import json
+import math
+import os
+from pathlib import Path
+import socket
+import statistics
+import subprocess
+
+import torch
+
+CALIBRATION_CASES = (
+    ("wave1_below", 9408, 4096, (3, 4, 5, 6, 7, 8)),
+    ("wave1_at", 9472, 4096, (3, 4, 5, 6, 7, 8)),
+    ("wave1_above", 9536, 4096, (3, 4, 5, 6, 7, 8)),
+    ("wide_11008x4096", 11008, 4096, (3, 4, 5, 6, 7, 8)),
+    ("wide_14336x4096", 14336, 4096, (3, 4, 5, 6, 7, 8)),
+    ("wave2_below", 18880, 4096, (3, 4, 5, 6, 7, 8)),
+    ("wave2_at", 18944, 4096, (3, 4, 5, 6, 7, 8)),
+    ("wave2_above", 19008, 4096, (3, 4, 5, 6, 7, 8)),
+    ("wave3_below_tall", 28352, 32768, (3, 4, 5, 6, 7, 8)),
+    ("wave3_at_tall", 28416, 32768, (3, 4, 5, 6, 7, 8)),
+    ("wave3_above_tall", 28480, 32768, (3, 4, 5, 6, 7, 8)),
+    ("vocab_128256x4096", 128256, 4096, (3, 4, 5, 6, 7, 8)),
+)
+DTYPES = {"fp16": torch.float16, "bf16": torch.bfloat16}
+VARIANTS = ("simt", "mma", "automatic")
+GEMM_ARGTYPES = [ct.c_void_p] * 8 + [ct.c_int32] * 5 + [ct.c_void_p]
+
+EARLY_SIMT = """    // fp32 and M<=3 are always SIMT regardless of GPU -- skip the props lookup.
+    if (is_fp32 || M <= 3) {"""
+FORCED_MMA_EARLY = """    // fp32 has no MMA implementation.
+    if (is_fp32) {"""
+AUTOMATIC_DISPATCH = """    const bool use_simt = (M == 4 && highbw_gddr) || undersubscribed || wide_n_simt || tall_k_simt ||
+                          sm103_tall_k_simt || (M <= 16 && mma_blocks * 4 <= num_sms) ||
+                          (M <= 32 && mma_blocks * 8 <= num_sms) || (K % 64 != 0); // MMA requirement"""
+
+
+def positive_int(value):
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def parse_case(value):
+    try:
+        name, n_text, k_text, m_text = value.split(":")
+        n = positive_int(n_text)
+        k = positive_int(k_text)
+        m_values = tuple(positive_int(item) for item in m_text.split(","))
+    except (ValueError, argparse.ArgumentTypeError) as error:
+        raise argparse.ArgumentTypeError("case must be NAME:N:K:M1,M2,...") from error
+    if not name or not m_values:
+        raise argparse.ArgumentTypeError("case name and M values must not be empty")
+    return name, n, k, m_values
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--build-root", required=True, type=Path)
+    parser.add_argument("--warmup", type=positive_int, default=20)
+    parser.add_argument("--repetitions", type=positive_int, default=100)
+    parser.add_argument("--rounds", type=positive_int, default=7)
+    parser.add_argument("--case", action="append", type=parse_case, help="NAME:N:K:M1,M2,...; overrides the grid")
+    parser.add_argument("--dtype", action="append", choices=tuple(DTYPES))
+    parser.add_argument("--seed", type=int, default=20260820)
+    return parser.parse_args()
+
+
+def run(command, *, cwd=None, stdin=None):
+    print("command=" + " ".join(str(part) for part in command), flush=True)
+    return subprocess.run(command, cwd=cwd, stdin=stdin, check=True)
+
+
+def require_sm103():
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is unavailable")
+    if torch.cuda.device_count() != 1:
+        raise RuntimeError(f"expected one visible GPU, found {torch.cuda.device_count()}")
+    capability = torch.cuda.get_device_capability(0)
+    properties = torch.cuda.get_device_properties(0)
+    if capability != (10, 3) or "B300" not in properties.name.upper():
+        raise RuntimeError(f"expected B300/SM103, found {properties.name} with capability {capability}")
+    return properties
+
+
+def replace_once(path, old, new):
+    source = path.read_text(encoding="utf-8")
+    if source.count(old) != 1:
+        raise RuntimeError(f"expected one dispatch block in {path}, found {source.count(old)}")
+    path.write_text(source.replace(old, new), encoding="utf-8")
+
+
+def extract_source(repo_root, destination):
+    destination.mkdir(parents=True)
+    archive = subprocess.Popen(["git", "archive", "HEAD"], cwd=repo_root, stdout=subprocess.PIPE)
+    try:
+        run(["tar", "-x", "-C", destination], stdin=archive.stdout)
+    finally:
+        if archive.stdout is not None:
+            archive.stdout.close()
+    if archive.wait() != 0:
+        raise subprocess.CalledProcessError(archive.returncode, ["git", "archive", "HEAD"])
+
+
+def force_variant(source_root, variant):
+    dispatch_path = source_root / "csrc" / "gemm_4bit.cu"
+    if variant == "simt":
+        replace_once(dispatch_path, AUTOMATIC_DISPATCH, "    const bool use_simt = true;")
+    elif variant == "mma":
+        replace_once(dispatch_path, EARLY_SIMT, FORCED_MMA_EARLY)
+        replace_once(
+            dispatch_path,
+            AUTOMATIC_DISPATCH,
+            "    const bool use_simt = K % 64 != 0; // Preserve the MMA alignment requirement.",
+        )
+    else:
+        raise ValueError(variant)
+
+
+def build_library(source_root, build_root):
+    run(
+        [
+            "cmake",
+            "-G",
+            "Ninja",
+            "-DCOMPUTE_BACKEND=cuda",
+            "-DCOMPUTE_CAPABILITY=103",
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-S",
+            source_root,
+            "-B",
+            build_root,
+        ]
+    )
+    parallel = int(os.environ.get("SLURM_CPUS_PER_TASK", os.cpu_count() or 1))
+    run(["cmake", "--build", build_root, "--parallel", str(parallel)])
+
+
+def prepare_libraries(repo_root, build_root):
+    if build_root.exists():
+        raise FileExistsError(f"build root must not exist: {build_root}")
+    build_root.mkdir(parents=True)
+    sources = {}
+    for variant in ("simt", "mma"):
+        source_root = build_root / f"source-{variant}"
+        extract_source(repo_root, source_root)
+        force_variant(source_root, variant)
+        build_library(source_root, build_root / f"build-{variant}")
+        sources[variant] = source_root
+
+    build_library(repo_root, build_root / "build-automatic")
+    cuda_version = "".join(torch.version.cuda.split(".")[:2])
+    libraries = {
+        variant: source_root / "bitsandbytes" / f"libbitsandbytes_cuda{cuda_version}.so"
+        for variant, source_root in sources.items()
+    }
+    for path in libraries.values():
+        if not path.is_file():
+            raise FileNotFoundError(path)
+    return libraries
+
+
+def load_library(path):
+    library = ct.CDLL(str(path.resolve()), mode=ct.RTLD_LOCAL)
+    for suffix in ("fp16", "bf16"):
+        function = getattr(library, f"cgemm_4bit_{suffix}")
+        function.argtypes = GEMM_ARGTYPES
+        function.restype = None
+    return library
+
+
+def percentile(values, fraction):
+    ordered = sorted(values)
+    position = fraction * (len(ordered) - 1)
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (position - lower)
+
+
+def summarize(samples):
+    return {
+        "median_ms": statistics.median(samples),
+        "p10_ms": percentile(samples, 0.10),
+        "p90_ms": percentile(samples, 0.90),
+        "min_ms": min(samples),
+        "max_ms": max(samples),
+    }
+
+
+def quantized_weight(functional, n, k, dtype):
+    weight = torch.empty((n, k), device="cuda", dtype=dtype)
+    weight.normal_(mean=0.0, std=k**-0.5)
+    packed, state = functional.quantize_4bit(
+        weight,
+        blocksize=64,
+        quant_type="nf4",
+        compress_statistics=True,
+    )
+    if state.offset.dtype != torch.float32:
+        raise RuntimeError(f"expected float32 nested offset, found {state.offset.dtype}")
+    reference_weight = functional.dequantize_4bit(packed, state).to(dtype)
+    del weight
+    return packed, state, reference_weight
+
+
+def invoke_native(library, activation, packed, state, dtype):
+    output = torch.empty((activation.shape[0], state.shape[0]), device=activation.device, dtype=dtype)
+    function = getattr(library, "cgemm_4bit_fp16" if dtype == torch.float16 else "cgemm_4bit_bf16")
+    function(
+        activation.data_ptr(),
+        packed.data_ptr(),
+        state.state2.absmax.data_ptr(),
+        state.absmax.data_ptr(),
+        state.state2.code.data_ptr(),
+        state.offset.data_ptr(),
+        output.data_ptr(),
+        None,
+        activation.shape[0],
+        state.shape[0],
+        activation.shape[1],
+        state.blocksize,
+        2,
+        torch._C._cuda_getCurrentRawStream(activation.device.index),
+    )
+    return output
+
+
+def invoke_automatic(activation, packed, state):
+    return torch.ops.bitsandbytes.gemm_4bit.default(
+        activation,
+        packed,
+        list(state.shape),
+        state.state2.absmax,
+        state.blocksize,
+        state.quant_type,
+        absmax_8bit=state.absmax,
+        absmax_code=state.state2.code,
+        absmax_offset=state.offset,
+    )
+
+
+def collect_interleaved(functions, warmup, repetitions, round_index):
+    for index in range(warmup):
+        for offset in range(len(VARIANTS)):
+            functions[VARIANTS[(index + round_index + offset) % len(VARIANTS)]]()
+    torch.cuda.synchronize()
+
+    events = {variant: [] for variant in VARIANTS}
+    for index in range(repetitions):
+        for offset in range(len(VARIANTS)):
+            variant = VARIANTS[(index + round_index + offset) % len(VARIANTS)]
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            functions[variant]()
+            end.record()
+            events[variant].append((start, end))
+    torch.cuda.synchronize()
+    return {variant: [start.elapsed_time(end) for start, end in events[variant]] for variant in VARIANTS}
+
+
+def automatic_internal_path(m, n, k, num_sms):
+    if m <= 3:
+        return "simt"
+    blocks = ((m + 31) // 32) * ((n + 63) // 64)
+    undersubscribed = (m <= 8 and blocks * 3 <= num_sms * 2) or (m == 4 and blocks <= num_sms)
+    sm103_tall_k_simt = k > n and m <= 5 and blocks >= num_sms * 3
+    use_simt = (
+        undersubscribed
+        or sm103_tall_k_simt
+        or (m <= 16 and blocks * 4 <= num_sms)
+        or (m <= 32 and blocks * 8 <= num_sms)
+        or k % 64 != 0
+    )
+    return "simt" if use_simt else "mma"
+
+
+def benchmark_cell(args, libraries, use_custom, num_sms, case_name, m, n, k, dtype, packed, state, reference_weight):
+    import torch.nn.functional as torch_functional
+
+    activation = torch.randn((m, k), device="cuda", dtype=dtype)
+    functions = {
+        "simt": lambda: invoke_native(libraries["simt"], activation, packed, state, dtype),
+        "mma": lambda: invoke_native(libraries["mma"], activation, packed, state, dtype),
+        "automatic": lambda: invoke_automatic(activation, packed, state),
+    }
+    reference = torch_functional.linear(activation, reference_weight)
+    correctness = {}
+    for variant, function in functions.items():
+        result = function()
+        torch.cuda.synchronize()
+        tolerance = 0.02 if dtype == torch.float16 else 0.08
+        torch.testing.assert_close(result, reference, rtol=0.02, atol=tolerance)
+        difference = result.float() - reference.float()
+        reference_rms = reference.float().square().mean().sqrt().item()
+        correctness[variant] = {
+            "max_abs_error": difference.abs().max().item(),
+            "relative_rms_error": difference.square().mean().sqrt().item() / max(reference_rms, 1e-12),
+            "finite": bool(torch.isfinite(result).all().item()),
+        }
+
+    samples = {variant: [] for variant in VARIANTS}
+    round_medians = {variant: [] for variant in VARIANTS}
+    for round_index in range(args.rounds):
+        round_samples = collect_interleaved(functions, args.warmup, args.repetitions, round_index)
+        for variant in VARIANTS:
+            samples[variant].extend(round_samples[variant])
+            round_medians[variant].append(statistics.median(round_samples[variant]))
+
+    stats = {variant: summarize(samples[variant]) for variant in VARIANTS}
+    simt_over_mma = stats["simt"]["median_ms"] / stats["mma"]["median_ms"]
+    return {
+        "type": "measurement",
+        "case": case_name,
+        "m": m,
+        "n": n,
+        "k": k,
+        "n_blocks_64": (n + 63) // 64,
+        "dtype": str(dtype).removeprefix("torch."),
+        "public_fused": bool(use_custom(0, dtype, m, n, k)),
+        "automatic_internal_path": automatic_internal_path(m, n, k, num_sms),
+        "stats": stats,
+        "simt_over_mma": simt_over_mma,
+        "winner_at_5_percent": ("simt" if simt_over_mma < 0.95 else "mma" if simt_over_mma > 1.05 else "noise"),
+        "correctness": correctness,
+        "round_medians_ms": round_medians,
+        "samples_ms": samples,
+    }
+
+
+def main():
+    args = parse_args()
+    properties = require_sm103()
+    repo_root = Path(__file__).resolve().parents[1]
+    tracked_status = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=no"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if tracked_status:
+        raise RuntimeError(f"tracked worktree must be clean:\n{tracked_status}")
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo_root, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    libraries_paths = prepare_libraries(repo_root, args.build_root.resolve())
+
+    import bitsandbytes
+    from bitsandbytes import functional
+    from bitsandbytes.backends.cuda.ops import _gemm_4bit_use_custom_cuda
+
+    libraries = {variant: load_library(path) for variant, path in libraries_paths.items()}
+    entrypoints = {
+        variant: ct.cast(library.cgemm_4bit_fp16, ct.c_void_p).value for variant, library in libraries.items()
+    }
+    if len(set(entrypoints.values())) != len(entrypoints):
+        raise RuntimeError(f"forced libraries resolved to the same entrypoint: {entrypoints}")
+
+    cases = tuple(args.case) if args.case else CALIBRATION_CASES
+    dtype_names = tuple(dict.fromkeys(args.dtype or tuple(DTYPES)))
+    torch.set_grad_enabled(False)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    metadata = {
+        "type": "metadata",
+        "git_commit": commit,
+        "job_id": os.environ.get("SLURM_JOB_ID"),
+        "hostname": socket.gethostname(),
+        "device": properties.name,
+        "compute_capability": list(torch.cuda.get_device_capability(0)),
+        "num_sms": properties.multi_processor_count,
+        "torch": torch.__version__,
+        "torch_cuda": torch.version.cuda,
+        "bitsandbytes": bitsandbytes.__version__,
+        "automatic_library": str(getattr(getattr(bitsandbytes.cextension.lib, "_lib", None), "_name", None)),
+        "forced_libraries": {variant: str(path) for variant, path in libraries_paths.items()},
+        "forced_entrypoints_distinct": True,
+        "cases": [{"name": name, "n": n, "k": k, "m_values": list(m_values)} for name, n, k, m_values in cases],
+        "dtypes": list(dtype_names),
+        "warmup": args.warmup,
+        "repetitions": args.repetitions,
+        "rounds": args.rounds,
+        "blocksize": 64,
+        "quant_type": "nf4",
+        "compress_statistics": True,
+        "seed": args.seed,
+    }
+
+    with args.output.open("w", encoding="utf-8") as output:
+        line = json.dumps(metadata, sort_keys=True)
+        print(line, flush=True)
+        output.write(line + "\n")
+        for case_index, (case_name, n, k, m_values) in enumerate(cases):
+            for dtype_name in dtype_names:
+                dtype = DTYPES[dtype_name]
+                packed, state, reference_weight = quantized_weight(functional, n, k, dtype)
+                for m in m_values:
+                    record = benchmark_cell(
+                        args,
+                        libraries,
+                        _gemm_4bit_use_custom_cuda,
+                        properties.multi_processor_count,
+                        case_name,
+                        m,
+                        n,
+                        k,
+                        dtype,
+                        packed,
+                        state,
+                        reference_weight,
+                    )
+                    line = json.dumps(record, sort_keys=True)
+                    print(line, flush=True)
+                    output.write(line + "\n")
+                    output.flush()
+                del packed, state, reference_weight
+                torch.cuda.empty_cache()
+            print(f"completed_case={case_index + 1}/{len(cases)} name={case_name}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/gemm_4bit.cu
+++ b/csrc/gemm_4bit.cu
@@ -96,8 +96,9 @@ static void gemm_4bit(
 
     // GDDR tall-K (K>N): K-loop too long relative to output tile at small M.
     const bool tall_k_simt = gddr_arch && K > N && M <= 17 && mma_blocks * 3 < num_sms;
-    // B300 at >=3 waves: SIMT wins for the two smallest fused tall-K shapes.
-    const bool sm103_tall_k_simt = cc_maj == 10 && cc_min == 3 && K > N && M <= 5 && mma_blocks >= num_sms * 3;
+    // B300 at 3-4 waves: SIMT wins for the two smallest fused tall-K shapes.
+    const bool sm103_tall_k_simt =
+        cc_maj == 10 && cc_min == 3 && K > N && M <= 5 && mma_blocks >= num_sms * 3 && mma_blocks < num_sms * 4;
 
     const bool use_simt = (M == 4 && highbw_gddr) || undersubscribed || wide_n_simt || tall_k_simt ||
                           sm103_tall_k_simt || (M <= 16 && mma_blocks * 4 <= num_sms) ||

--- a/csrc/gemm_4bit.cu
+++ b/csrc/gemm_4bit.cu
@@ -96,10 +96,12 @@ static void gemm_4bit(
 
     // GDDR tall-K (K>N): K-loop too long relative to output tile at small M.
     const bool tall_k_simt = gddr_arch && K > N && M <= 17 && mma_blocks * 3 < num_sms;
+    // B300 at >=3 waves: SIMT wins for the two smallest fused tall-K shapes.
+    const bool sm103_tall_k_simt = cc_maj == 10 && cc_min == 3 && K > N && M <= 5 && mma_blocks >= num_sms * 3;
 
     const bool use_simt = (M == 4 && highbw_gddr) || undersubscribed || wide_n_simt || tall_k_simt ||
-                          (M <= 16 && mma_blocks * 4 <= num_sms) || (M <= 32 && mma_blocks * 8 <= num_sms) ||
-                          (K % 64 != 0); // MMA requirement
+                          sm103_tall_k_simt || (M <= 16 && mma_blocks * 4 <= num_sms) ||
+                          (M <= 32 && mma_blocks * 8 <= num_sms) || (K % 64 != 0); // MMA requirement
 
     if (!use_simt) {
 #if defined(BNB_HAS_GEMM4BIT_SM80)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -375,6 +375,69 @@ class Test4bitBlockwiseQuantOps:
         torch.testing.assert_close(out, ref)
 
 
+_SM103_GEMM_4BIT_CASES = (
+    pytest.param(torch.float16, "nf4", False, False, 32, 28672, id="fp16-nf4-plain-nobias-block32-aligned"),
+    pytest.param(torch.float16, "fp4", True, True, 64, 28672, id="fp16-fp4-nested-bias-block64-aligned"),
+    pytest.param(torch.bfloat16, "nf4", True, False, 128, 28672, id="bf16-nf4-nested-nobias-block128-aligned"),
+    pytest.param(torch.bfloat16, "fp4", False, True, 256, 28672, id="bf16-fp4-plain-bias-block256-aligned"),
+    pytest.param(torch.float16, "nf4", False, False, 32, 28640, id="fp16-nf4-plain-nobias-block32-nonaligned"),
+)
+
+
+@pytest.mark.parametrize("device", get_available_devices(no_cpu=True))
+@pytest.mark.parametrize(
+    "dtype,quant_type,compress_statistics,has_bias,blocksize,K",
+    _SM103_GEMM_4BIT_CASES,
+)
+def test_gemm_4bit_sm103_tall_k_dispatch(device, dtype, quant_type, compress_statistics, has_bias, blocksize, K):
+    if device != "cuda" or torch.cuda.get_device_capability() != (10, 3):
+        pytest.skip("SM103 dispatch coverage requires a B300 GPU")
+
+    N = 28416  # 444 output tiles: exactly three waves on a 148-SM B300.
+    weight = torch.randn(N, K, dtype=dtype, device=device) / (K**0.5)
+    packed, state = bitsandbytes.functional.quantize_4bit(
+        weight,
+        blocksize=blocksize,
+        quant_type=quant_type,
+        compress_statistics=compress_statistics,
+    )
+    reference_weight = bitsandbytes.functional.dequantize_4bit(packed, state).to(dtype)
+    del weight
+
+    for M in (4, 5, 6):
+        activation = torch.randn(M, K, dtype=dtype, device=device)
+        bias = torch.randn(N, dtype=dtype, device=device) if has_bias else None
+        reference = torch.nn.functional.linear(activation, reference_weight, bias)
+        if compress_statistics:
+            output = torch.ops.bitsandbytes.gemm_4bit.default(
+                activation,
+                packed,
+                list(state.shape),
+                state.state2.absmax,
+                blocksize,
+                quant_type,
+                bias=bias,
+                absmax_8bit=state.absmax,
+                absmax_code=state.state2.code,
+                absmax_offset=state.offset,
+            )
+        else:
+            output = torch.ops.bitsandbytes.gemm_4bit.default(
+                activation,
+                packed,
+                list(state.shape),
+                state.absmax,
+                blocksize,
+                quant_type,
+                bias=bias,
+            )
+
+        assert output.shape == reference.shape
+        assert output.dtype == dtype
+        assert torch.isfinite(output).all()
+        torch.testing.assert_close(output, reference, rtol=0.02, atol=0.02 if dtype == torch.float16 else 0.08)
+
+
 class TestNonContiguousInputs:
     """Regression tests for #1342 and #1690: quantization must handle non-contiguous tensors correctly."""
 


### PR DESCRIPTION
## Summary

- Add an exact SM103/B300 internal dispatch rule that selects the existing SIMT fused 4-bit GEMM only for tall-K `M <= 5` shapes from three up to, but not including, four output-tile waves.
- Retain MMA at four and later waves, for adjacent `M >= 6` shapes, and on every non-SM103 architecture.
- Add a tracked B300 benchmark CLI that isolates automatic, forced-SIMT, and legal forced-MMA builds below `--build-root`, supports native or official-wheel-compatible CUDA targets, and records interleaved CUDA-event samples as JSONL.
- Add focused public-op correctness coverage across FP16/BF16, NF4/FP4, nested statistics, bias, block sizes 32/64/128/256, and a non-64-aligned K control.

Fork issue: https://github.com/heiheiha798/bitsandbytes/issues/3

## Problem and design

The internal dispatch in `csrc/gemm_4bit.cu` had no SM103-specific SIMT/MMA calibration. Direct forced-path measurements on a 148-SM B300 show a stable, dtype-independent SIMT region for public fused tall-K `M=4,5` calls at the start of the third output-tile wave. Later-wave validation found a mixed result at exactly four waves and a clear MMA win at eight waves, so the final predicate is deliberately bounded:

```cpp
cc_maj == 10 && cc_min == 3 && K > N && M <= 5 &&
    mma_blocks >= num_sms * 3 && mma_blocks < num_sms * 4
```

This changes no kernel math, public API, Python top-level dispatch, wheel target, dependency, or non-SM103 branch. At four and later waves the candidate retains the upstream MMA decision. The benchmark's forced-path edits exist only in temporary source trees and do not ship as an API.

## B300 performance

Native-SM103 calibration used baseline job 4821 at `95f9af309d4d5793847169c39288dcd3fcbdf564` and candidate job 4829 at `dc7eff3e7cfc2adc61874c82d494da897f09ae9f`. It covered the 148/296/444-block boundaries, real projection controls, `M=3..8`, and FP16/BF16. Those native results established the initial three-wave target region.

Final job 4851 validated commit `7d9c98730d6d483f43e39d3af140a89498943953` using the official CUDA 13 x64 wheel target input `75;80;86;89;90;100;120`, which CMake expanded to `75-real;80-real;86-real;89-real;90-real;100-real;120`. Each path used 20 warmups followed by 7 rounds of 100 CUDA-event samples, with variant order rotating for every sample. Values below are p10 / median / p90 milliseconds from job 4851; old path is forced MMA.

| N x K | dtype | M | Old MMA ms | Candidate auto ms | Median reduction |
|---|---:|---:|---:|---:|---:|
| 28416 x 32768 | FP16 | 4 | 1.4180 / 1.4201 / 1.4222 | 0.9399 / 0.9420 / 0.9453 | 33.7% |
| 28416 x 32768 | BF16 | 4 | 1.4181 / 1.4201 / 1.4222 | 0.9553 / 0.9593 / 0.9621 | 32.4% |
| 28416 x 32768 | FP16 | 5 | 1.4219 / 1.4241 / 1.4262 | 1.2706 / 1.2717 / 1.2727 | 10.7% |
| 28416 x 32768 | BF16 | 5 | 1.4211 / 1.4232 / 1.4254 | 1.2665 / 1.2677 / 1.2686 | 10.9% |
| 28480 x 32768 | FP16 | 4 | 1.4048 / 1.4068 / 1.4096 | 0.9458 / 0.9481 / 0.9614 | 32.6% |
| 28480 x 32768 | BF16 | 4 | 1.4048 / 1.4068 / 1.4096 | 0.9470 / 0.9500 / 0.9644 | 32.5% |
| 28480 x 32768 | FP16 | 5 | 1.4078 / 1.4099 / 1.4120 | 1.2777 / 1.2788 / 1.2798 | 9.3% |
| 28480 x 32768 | BF16 | 5 | 1.4078 / 1.4099 / 1.4120 | 1.2747 / 1.2765 / 1.2769 | 9.5% |

All seven round-median SIMT/MMA ratios remain below 0.95 for every three-wave target. Across FP16/BF16, the overall ratios are 0.663-0.675 for `M=4` and 0.891-0.907 for `M=5`.

The same job directly checks why the upper bound is required:

| Output blocks | Wave point | M | SIMT/MMA median ratio across dtypes | Winner beyond 5% |
|---:|---:|---:|---:|---:|
| 592 | 4 waves | 4 | 0.901-0.902 | SIMT |
| 592 | 4 waves | 5 | 1.168-1.171 | MMA |
| 1184 | 8 waves | 4 | 1.595-1.625 | MMA |
| 1184 | 8 waves | 5 | 2.019-2.025 | MMA |

The final automatic dispatch chooses SIMT at 444/445 blocks and MMA at 592/1184 blocks, with adjacent `M=6` controls also on MMA. Automatic median latency matches its selected forced path within 0.11% over all 24 cells. The conservative common upper bound intentionally forgoes the isolated `M=4` win at exactly four waves instead of introducing an M-dependent special case.

Job 4837, run at the pre-bound commit `187e4e4faa4d62ba060b0e7ec461ec134b8c2d9c`, provided the decision-changing compatible-path evidence that led to this upper bound. Job 4834 is only a pre-build wrapper failure caused by passing already-suffixed CMake targets; it produced no benchmark data and is not performance evidence.

## Reproduce

Run the following inside a one-GPU B300/SM103 Slurm allocation from a clean checkout. `--build-root` must not already exist.

```bash
python benchmarking/gemm_4bit_sm103_simt_mma.py \
  --output /tmp/bnb-sm103-compatible-range.jsonl \
  --build-root /tmp/bnb-sm103-compatible-range-build \
  --compute-capability '75;80;86;89;90;100;120' \
  --warmup 20 \
  --repetitions 100 \
  --rounds 7 \
  --case wave3_at_tall:28416:32768:4,5,6 \
  --case wave3_above_tall:28480:32768:4,5,6 \
  --case wave4_tall_k49152:37888:49152:4,5,6 \
  --case wave8_tall_k81920:75776:81920:4,5,6 \
  --dtype fp16 \
  --dtype bf16
```

Omitting `--compute-capability` builds native SM103 by default. The default grid also includes the 148/296/444-block boundaries, 11008x4096 and 14336x4096 projections, and a 128256x4096 vocabulary projection. The CLI requires exactly one visible B300 with CC 10.3 and records complete samples, round medians, p10/p90, correctness, commit, job, GPU, and software metadata. All three builds and the automatic package import are isolated below `--build-root`; the checkout library is not overwritten.

## Correctness and checks

Job 4851 identity: NVIDIA B300 SXM6 AC, CC 10.3, 148 SMs, driver 580.126.09, CUDA compiler 13.0.88, PyTorch 2.13.0+cu130, Python 3.12.3.

- Exact-head official-compatible automatic, forced-SIMT, and forced-MMA builds passed from temporary source trees at `7d9c98730d6d483f43e39d3af140a89498943953`.
- The exact-head public automatic benchmark ran 24 cells with 700 samples and 7 round medians per path per cell. All 72 path outputs were finite and repository-tolerance reference-close, including 444/445/592/1184-block M=4/5/6 coverage. Maximum absolute error was 0.03125 and maximum relative RMS error was 0.011809.
- The four pytest selections below ran later in job 4851, but their separate processes imported the checkout native library previously linked by native job 4829 at `dc7eff3e7cfc2adc61874c82d494da897f09ae9f`; they are regression evidence, not exact-head temporary-library validation. The 5 focused cases exercise the 444-block target where `dc7eff3` and the final bounded predicate select the same paths. A rerun is unnecessary because the exact-head public automatic benchmark above directly loads and path-checks the final temporary library and covers every changed and restored boundary.
- `BNB_TEST_DEVICE=cuda pytest -vv tests/test_ops.py -k gemm_4bit_sm103_tall_k_dispatch`: 5 passed using the `dc7eff3` checkout native artifact.
- `BNB_TEST_DEVICE=cuda pytest -q tests/test_ops.py -k 'test_gemm_4bit and not sm103_tall_k_dispatch'`: 100 passed using the `dc7eff3` checkout native artifact.
- `BNB_TEST_DEVICE=cuda pytest -q tests/test_functional.py -k matmul_4bit`: 1153 passed using the `dc7eff3` checkout native artifact.
- `BNB_TEST_DEVICE=cuda pytest -q tests/test_autograd.py -k matmul_4bit`: 384 passed using the `dc7eff3` checkout native artifact.
- CPU-only `tests/test_ops.py` collection: 392 tests collected without a CUDA import/collection failure; the 5 SM103 cases skip as intended.
- Submission preflight `pre-commit run --all-files`: all 10 hooks passed at the exact final head.
- `git diff --check` passed at the exact final head.

Raw workspace evidence:

- `benchmark-evidence/cycle2/slurm-4821-simt-mma.out`
- `benchmark-evidence/cycle2/sm103-simt-mma-job-4821.jsonl`
- `benchmark-evidence/cycle2/slurm-4829-candidate.out`
- `benchmark-evidence/cycle2/sm103-candidate-job-4829.jsonl`
- `benchmark-evidence/cycle2/slurm-4834-compatible-range.out` (pre-build failure, not evidence)
- `benchmark-evidence/cycle2/slurm-4837-compatible-range.out`
- `benchmark-evidence/cycle2/sm103-compatible-range-job-4837.jsonl`
- `benchmark-evidence/cycle2/slurm-4851-compatible-range.out`
- `benchmark-evidence/cycle2/sm103-compatible-range-job-4851.jsonl`

## Limits and risk

- Measurements are from one physical B300. Native-SM103 and official-compatible builds are reported separately; no B200 hardware run was used.
- The exact runtime SM103 guard prevents a dispatch change on SM100 or any other architecture.
- The rule intentionally excludes the mixed exact-four-wave point and all later waves. This leaves one measured `M=4` opportunity unused in order to keep one maintainable, dtype-independent rule with no adjacent regression.
- Job 4851's pytest subprocesses used the earlier `dc7eff3` checkout native artifact; exact-head binary correctness comes from the path-asserted 24-cell public automatic benchmark, not those pytest counts.
- Fork CI is repository-gated; the full documented pre-commit workflow and focused B300 CUDA selections were run directly instead.

## Tracking

- Fork engineering record: https://github.com/heiheiha798/bitsandbytes/pull/4
